### PR TITLE
feat(interop): add A2A (Agent-to-Agent) protocol support

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,7 +6,7 @@ pub mod workspace;
 pub use schema::{
     apply_runtime_proxy_to_builder, build_runtime_proxy_client,
     build_runtime_proxy_client_with_timeouts, runtime_proxy_config, set_runtime_proxy_config,
-    AgentConfig, AssemblyAiSttConfig, AuditConfig, AutonomyConfig, BackupConfig,
+    A2aConfig, AgentConfig, AssemblyAiSttConfig, AuditConfig, AutonomyConfig, BackupConfig,
     BrowserComputerUseConfig, BrowserConfig, BuiltinHooksConfig, ChannelsConfig,
     ClassificationRule, CloudOpsConfig, ComposioConfig, Config, ConversationalAiConfig, CostConfig,
     CronConfig, DataRetentionConfig, DeepgramSttConfig, DelegateAgentConfig, DiscordConfig,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -339,6 +339,10 @@ pub struct Config {
     /// Plugin system configuration (`[plugins]`).
     #[serde(default)]
     pub plugins: PluginsConfig,
+
+    /// A2A (Agent-to-Agent) protocol configuration (`[a2a]`).
+    #[serde(default)]
+    pub a2a: A2aConfig,
 }
 
 /// Multi-client workspace isolation configuration.
@@ -1922,6 +1926,66 @@ impl Default for HttpRequestConfig {
             max_response_size: default_http_max_response_size(),
             timeout_secs: default_http_timeout_secs(),
             allow_private_hosts: false,
+        }
+    }
+}
+
+// ── A2A (Agent-to-Agent) protocol ───────────────────────────────
+
+fn default_a2a_timeout_secs() -> u64 {
+    60
+}
+
+/// A2A (Agent-to-Agent) protocol configuration.
+///
+/// Enables inter-agent communication via the A2A open standard (Linux Foundation).
+/// When enabled, registers both an outbound client tool (`a2a`) and inbound server
+/// endpoints (`GET /.well-known/agent-card.json`, `POST /a2a`).
+///
+/// Compatibility: additive and disabled by default; existing configs remain valid when omitted.
+/// Rollback/migration: remove `[a2a]` or keep `enabled = false` to disable.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct A2aConfig {
+    /// Enable A2A protocol support (client tool + server endpoints). Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Agent name for the agent card. Falls back to "ZeroClaw Agent".
+    #[serde(default)]
+    pub agent_name: Option<String>,
+    /// Agent description for the agent card.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Agent version string. Default: crate version.
+    #[serde(default)]
+    pub version: Option<String>,
+    /// Externally-reachable base URL for the agent card.
+    /// Default: `http://{gateway.host}:{gateway.port}`.
+    #[serde(default)]
+    pub public_url: Option<String>,
+    /// Bearer token for authenticating inbound A2A requests.
+    /// If empty, falls back to the gateway pairing token.
+    #[serde(default)]
+    pub bearer_token: Option<String>,
+    /// Skills/capabilities to advertise in the agent card.
+    /// If empty, auto-derived from enabled tools.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    /// Request timeout in seconds for outbound A2A calls. Default: 60.
+    #[serde(default = "default_a2a_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+impl Default for A2aConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            agent_name: None,
+            description: None,
+            version: None,
+            public_url: None,
+            bearer_token: None,
+            capabilities: vec![],
+            timeout_secs: default_a2a_timeout_secs(),
         }
     }
 }
@@ -5991,6 +6055,7 @@ impl Default for Config {
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
             plugins: PluginsConfig::default(),
+            a2a: A2aConfig::default(),
         }
     }
 }
@@ -8427,6 +8492,7 @@ default_temperature = 0.7
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
             plugins: PluginsConfig::default(),
+            a2a: A2aConfig::default(),
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -8760,6 +8826,7 @@ tool_dispatcher = "xml"
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
             plugins: PluginsConfig::default(),
+            a2a: A2aConfig::default(),
         };
 
         config.save().await.unwrap();

--- a/src/gateway/a2a.rs
+++ b/src/gateway/a2a.rs
@@ -1,0 +1,494 @@
+//! A2A (Agent-to-Agent) protocol server handlers.
+//!
+//! Serves the agent card at `GET /.well-known/agent-card.json` and processes
+//! inbound JSON-RPC 2.0 task requests at `POST /a2a`.
+
+use super::AppState;
+use axum::{
+    extract::State,
+    http::{header, HeaderMap, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+// ── Types ────────────────────────────────────────────────────────
+
+/// In-memory store for A2A task state.
+pub struct TaskStore {
+    tasks: RwLock<HashMap<String, TaskState>>,
+}
+
+impl TaskStore {
+    pub fn new() -> Self {
+        Self {
+            tasks: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+/// State of an inbound A2A task.
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskState {
+    pub id: String,
+    pub status: TaskStatus,
+    pub artifacts: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskStatus {
+    Submitted,
+    Working,
+    Completed,
+    Failed,
+}
+
+/// JSON-RPC 2.0 request envelope.
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// JSON-RPC 2.0 response envelope.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+// ── Agent card generation ────────────────────────────────────────
+
+/// Generate the A2A agent card from configuration.
+pub fn generate_agent_card(config: &crate::config::Config) -> serde_json::Value {
+    let a2a = &config.a2a;
+
+    let name = a2a
+        .agent_name
+        .clone()
+        .unwrap_or_else(|| "ZeroClaw Agent".to_string());
+
+    let description = a2a
+        .description
+        .clone()
+        .unwrap_or_else(|| "ZeroClaw autonomous agent".to_string());
+
+    let version = a2a
+        .version
+        .clone()
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+    let base_url = a2a
+        .public_url
+        .clone()
+        .unwrap_or_else(|| format!("http://{}:{}", config.gateway.host, config.gateway.port));
+
+    let capabilities: Vec<serde_json::Value> = if a2a.capabilities.is_empty() {
+        vec![json!({
+            "name": "general",
+            "description": "General-purpose autonomous agent"
+        })]
+    } else {
+        a2a.capabilities
+            .iter()
+            .map(|c| json!({ "name": c }))
+            .collect()
+    };
+
+    json!({
+        "name": name,
+        "description": description,
+        "version": version,
+        "url": base_url,
+        "capabilities": capabilities,
+        "defaultInputModes": ["text"],
+        "defaultOutputModes": ["text"],
+        "skills": capabilities,
+        "provider": {
+            "organization": "ZeroClaw"
+        },
+        "authentication": {
+            "schemes": ["bearer"]
+        },
+        "supportsTaskLifecycle": true
+    })
+}
+
+// ── Handlers ─────────────────────────────────────────────────────
+
+/// `GET /.well-known/agent-card.json` — unauthenticated discovery endpoint.
+pub async fn handle_agent_card(State(state): State<AppState>) -> impl IntoResponse {
+    match &state.a2a_agent_card {
+        Some(card) => (StatusCode::OK, Json(card.as_ref().clone())).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "A2A protocol not enabled"})),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /a2a` — authenticated JSON-RPC 2.0 task endpoint.
+pub async fn handle_a2a_rpc(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<JsonRpcRequest>,
+) -> impl IntoResponse {
+    // Check feature enabled
+    let (Some(ref _card), Some(ref task_store)) = (&state.a2a_agent_card, &state.a2a_task_store)
+    else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"jsonrpc": "2.0", "id": null, "error": {"code": -32000, "message": "A2A protocol not enabled"}})),
+        )
+            .into_response();
+    };
+
+    // Authenticate
+    if let Err(resp) = require_a2a_auth(&state, &headers) {
+        return resp.into_response();
+    }
+
+    // Validate JSON-RPC version
+    if body.jsonrpc != "2.0" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(rpc_error(body.id, -32600, "Invalid JSON-RPC version")),
+        )
+            .into_response();
+    }
+
+    match body.method.as_str() {
+        "tasks/send" => Box::pin(handle_tasks_send(&state, task_store, body))
+            .await
+            .into_response(),
+        "tasks/get" => handle_tasks_get(task_store, body).await.into_response(),
+        _ => (
+            StatusCode::OK,
+            Json(rpc_error(
+                body.id,
+                -32601,
+                &format!("Method not found: {}", body.method),
+            )),
+        )
+            .into_response(),
+    }
+}
+
+// ── Auth helper ──────────────────────────────────────────────────
+
+fn require_a2a_auth(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    // Extract bearer token from Authorization header
+    let token = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|auth| auth.strip_prefix("Bearer "))
+        .unwrap_or("");
+
+    // Check dedicated A2A bearer token first
+    {
+        let config = state.config.lock();
+        if let Some(ref a2a_token) = config.a2a.bearer_token {
+            if !a2a_token.is_empty() {
+                return if token == a2a_token {
+                    Ok(())
+                } else {
+                    Err((
+                        StatusCode::UNAUTHORIZED,
+                        Json(
+                            json!({"jsonrpc": "2.0", "id": null, "error": {"code": -32000, "message": "Unauthorized"}}),
+                        ),
+                    ))
+                };
+            }
+        }
+    }
+
+    // Fall back to gateway pairing auth
+    if !state.pairing.require_pairing() {
+        return Ok(());
+    }
+
+    if state.pairing.is_authenticated(token) {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::UNAUTHORIZED,
+            Json(
+                json!({"jsonrpc": "2.0", "id": null, "error": {"code": -32000, "message": "Unauthorized"}}),
+            ),
+        ))
+    }
+}
+
+// ── Method handlers ──────────────────────────────────────────────
+
+async fn handle_tasks_send(
+    state: &AppState,
+    task_store: &Arc<TaskStore>,
+    req: JsonRpcRequest,
+) -> (StatusCode, Json<serde_json::Value>) {
+    // Extract message text from params
+    let message = req
+        .params
+        .pointer("/message/parts")
+        .and_then(|parts| parts.as_array())
+        .and_then(|parts| {
+            parts.iter().find_map(|p| {
+                if p.get("type").and_then(|t| t.as_str()) == Some("text") {
+                    p.get("text").and_then(|t| t.as_str()).map(String::from)
+                } else {
+                    None
+                }
+            })
+        })
+        .or_else(|| {
+            // Simple text fallback
+            req.params
+                .get("message")
+                .and_then(|m| m.as_str())
+                .map(String::from)
+        });
+
+    let Some(message) = message else {
+        return (
+            StatusCode::OK,
+            Json(rpc_error(
+                req.id,
+                -32602,
+                "Invalid params: missing message text",
+            )),
+        );
+    };
+
+    let task_id = uuid::Uuid::new_v4().to_string();
+
+    // Store task as working
+    {
+        let mut tasks = task_store.tasks.write().await;
+        tasks.insert(
+            task_id.clone(),
+            TaskState {
+                id: task_id.clone(),
+                status: TaskStatus::Working,
+                artifacts: vec![],
+            },
+        );
+    }
+
+    // Process via agent pipeline
+    let config = state.config.lock().clone();
+    let session_id = format!("a2a-{task_id}");
+    match Box::pin(crate::agent::process_message(config, &message, Some(&session_id))).await {
+        Ok(response) => {
+            let artifact = json!({
+                "type": "text",
+                "parts": [{ "type": "text", "text": response }]
+            });
+            let mut tasks = task_store.tasks.write().await;
+            if let Some(task) = tasks.get_mut(&task_id) {
+                task.status = TaskStatus::Completed;
+                task.artifacts = vec![artifact.clone()];
+            }
+
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": req.id,
+                    "result": {
+                        "id": task_id,
+                        "status": "completed",
+                        "artifacts": [artifact]
+                    }
+                })),
+            )
+        }
+        Err(e) => {
+            let mut tasks = task_store.tasks.write().await;
+            if let Some(task) = tasks.get_mut(&task_id) {
+                task.status = TaskStatus::Failed;
+            }
+
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": req.id,
+                    "result": {
+                        "id": task_id,
+                        "status": "failed",
+                        "error": e.to_string()
+                    }
+                })),
+            )
+        }
+    }
+}
+
+async fn handle_tasks_get(
+    task_store: &Arc<TaskStore>,
+    req: JsonRpcRequest,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let task_id = req.params.get("id").and_then(|v| v.as_str()).unwrap_or("");
+
+    if task_id.is_empty() {
+        return (
+            StatusCode::OK,
+            Json(rpc_error(req.id, -32602, "Invalid params: missing task id")),
+        );
+    }
+
+    let tasks = task_store.tasks.read().await;
+    match tasks.get(task_id) {
+        Some(task) => (
+            StatusCode::OK,
+            Json(json!({
+                "jsonrpc": "2.0",
+                "id": req.id,
+                "result": {
+                    "id": task.id,
+                    "status": task.status,
+                    "artifacts": task.artifacts
+                }
+            })),
+        ),
+        None => (
+            StatusCode::OK,
+            Json(rpc_error(
+                req.id,
+                -32001,
+                &format!("Task not found: {task_id}"),
+            )),
+        ),
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+fn rpc_error(id: serde_json::Value, code: i32, message: &str) -> serde_json::Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_card_generation_defaults() {
+        let config = crate::config::Config {
+            a2a: crate::config::A2aConfig {
+                enabled: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let card = generate_agent_card(&config);
+        assert_eq!(card["name"], "ZeroClaw Agent");
+        assert!(card["url"].as_str().unwrap().starts_with("http://"));
+        assert!(card["capabilities"].is_array());
+        assert!(card["authentication"]["schemes"].is_array());
+    }
+
+    #[test]
+    fn agent_card_generation_custom() {
+        let config = crate::config::Config {
+            a2a: crate::config::A2aConfig {
+                enabled: true,
+                agent_name: Some("my-agent".into()),
+                description: Some("My custom agent".into()),
+                public_url: Some("https://agent.example.com".into()),
+                capabilities: vec!["search".into(), "code".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let card = generate_agent_card(&config);
+        assert_eq!(card["name"], "my-agent");
+        assert_eq!(card["description"], "My custom agent");
+        assert_eq!(card["url"], "https://agent.example.com");
+        assert_eq!(card["capabilities"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn rpc_error_format() {
+        let err = rpc_error(json!(1), -32600, "Test error");
+        assert_eq!(err["jsonrpc"], "2.0");
+        assert_eq!(err["id"], 1);
+        assert_eq!(err["error"]["code"], -32600);
+        assert_eq!(err["error"]["message"], "Test error");
+    }
+
+    #[tokio::test]
+    async fn task_store_lifecycle() {
+        let store = TaskStore::new();
+        let task_id = "test-123".to_string();
+
+        // Insert
+        {
+            let mut tasks = store.tasks.write().await;
+            tasks.insert(
+                task_id.clone(),
+                TaskState {
+                    id: task_id.clone(),
+                    status: TaskStatus::Working,
+                    artifacts: vec![],
+                },
+            );
+        }
+
+        // Read
+        {
+            let tasks = store.tasks.read().await;
+            let task = tasks.get(&task_id).unwrap();
+            assert_eq!(task.status, TaskStatus::Working);
+        }
+
+        // Update
+        {
+            let mut tasks = store.tasks.write().await;
+            if let Some(task) = tasks.get_mut(&task_id) {
+                task.status = TaskStatus::Completed;
+                task.artifacts = vec![json!({"text": "done"})];
+            }
+        }
+
+        // Verify
+        {
+            let tasks = store.tasks.read().await;
+            let task = tasks.get(&task_id).unwrap();
+            assert_eq!(task.status, TaskStatus::Completed);
+            assert_eq!(task.artifacts.len(), 1);
+        }
+    }
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -7,6 +7,7 @@
 //! - Request timeouts (30s) to prevent slow-loris attacks
 //! - Header sanitization (handled by axum/hyper)
 
+pub mod a2a;
 pub mod api;
 pub mod api_pairing;
 #[cfg(feature = "plugins-wasm")]
@@ -341,6 +342,10 @@ pub struct AppState {
     pub device_registry: Option<Arc<api_pairing::DeviceRegistry>>,
     /// Pending pairing request store
     pub pending_pairings: Option<Arc<api_pairing::PairingStore>>,
+    /// A2A agent card (pre-generated JSON); `None` when A2A is disabled
+    pub a2a_agent_card: Option<Arc<serde_json::Value>>,
+    /// A2A in-memory task store; `None` when A2A is disabled
+    pub a2a_task_store: Option<Arc<a2a::TaskStore>>,
 }
 
 /// Run the HTTP gateway using axum with proper HTTP/1.1 compliance.
@@ -706,6 +711,16 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         None
     };
 
+    // A2A protocol support
+    let (a2a_agent_card, a2a_task_store) = if config.a2a.enabled {
+        (
+            Some(Arc::new(a2a::generate_agent_card(&config))),
+            Some(Arc::new(a2a::TaskStore::new())),
+        )
+    } else {
+        (None, None)
+    };
+
     let state = AppState {
         config: config_state,
         provider,
@@ -734,6 +749,8 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         session_backend,
         device_registry,
         pending_pairings,
+        a2a_agent_card,
+        a2a_task_store,
     };
 
     // Config PUT needs larger body limit (1MB)
@@ -747,6 +764,9 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .route("/admin/shutdown", post(handle_admin_shutdown))
         .route("/admin/paircode", get(handle_admin_paircode))
         .route("/admin/paircode/new", post(handle_admin_paircode_new))
+        // ── A2A protocol routes ──
+        .route("/.well-known/agent-card.json", get(a2a::handle_agent_card))
+        .route("/a2a", post(a2a::handle_a2a_rpc))
         // ── Existing routes ──
         .route("/health", get(handle_health))
         .route("/metrics", get(handle_metrics))
@@ -1906,6 +1926,8 @@ mod tests {
             session_backend: None,
             device_registry: None,
             pending_pairings: None,
+            a2a_agent_card: None,
+            a2a_task_store: None,
         };
 
         let response = handle_metrics(State(state)).await.into_response();
@@ -1961,6 +1983,8 @@ mod tests {
             session_backend: None,
             device_registry: None,
             pending_pairings: None,
+            a2a_agent_card: None,
+            a2a_task_store: None,
         };
 
         let response = handle_metrics(State(state)).await.into_response();
@@ -2340,6 +2364,8 @@ mod tests {
             session_backend: None,
             device_registry: None,
             pending_pairings: None,
+            a2a_agent_card: None,
+            a2a_task_store: None,
         };
 
         let mut headers = HeaderMap::new();
@@ -2409,6 +2435,8 @@ mod tests {
             session_backend: None,
             device_registry: None,
             pending_pairings: None,
+            a2a_agent_card: None,
+            a2a_task_store: None,
         };
 
         let headers = HeaderMap::new();
@@ -2490,6 +2518,8 @@ mod tests {
             session_backend: None,
             device_registry: None,
             pending_pairings: None,
+            a2a_agent_card: None,
+            a2a_task_store: None,
         };
 
         let response = handle_webhook(
@@ -2543,6 +2573,8 @@ mod tests {
             session_backend: None,
             device_registry: None,
             pending_pairings: None,
+            a2a_agent_card: None,
+            a2a_task_store: None,
         };
 
         let mut headers = HeaderMap::new();
@@ -2601,6 +2633,8 @@ mod tests {
             session_backend: None,
             device_registry: None,
             pending_pairings: None,
+            a2a_agent_card: None,
+            a2a_task_store: None,
         };
 
         let mut headers = HeaderMap::new();
@@ -2664,6 +2698,8 @@ mod tests {
             session_backend: None,
             device_registry: None,
             pending_pairings: None,
+            a2a_agent_card: None,
+            a2a_task_store: None,
         };
 
         let response = Box::pin(handle_nextcloud_talk_webhook(
@@ -2723,6 +2759,8 @@ mod tests {
             session_backend: None,
             device_registry: None,
             pending_pairings: None,
+            a2a_agent_card: None,
+            a2a_task_store: None,
         };
 
         let mut headers = HeaderMap::new();

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -193,6 +193,7 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         knowledge: crate::config::KnowledgeConfig::default(),
         linkedin: crate::config::LinkedInConfig::default(),
         plugins: crate::config::PluginsConfig::default(),
+        a2a: crate::config::A2aConfig::default(),
     };
 
     println!(
@@ -567,6 +568,7 @@ async fn run_quick_setup_with_home(
         knowledge: crate::config::KnowledgeConfig::default(),
         linkedin: crate::config::LinkedInConfig::default(),
         plugins: crate::config::PluginsConfig::default(),
+        a2a: crate::config::A2aConfig::default(),
     };
 
     config.save().await?;

--- a/src/tools/a2a.rs
+++ b/src/tools/a2a.rs
@@ -1,0 +1,409 @@
+//! A2A (Agent-to-Agent) protocol client tool.
+//!
+//! Enables the agent to discover and communicate with remote A2A-compatible
+//! agents via the A2A open standard (Linux Foundation). Supports four actions:
+//! `discover`, `send`, `status`, and `result`.
+
+use super::traits::{Tool, ToolResult};
+use crate::security::SecurityPolicy;
+use async_trait::async_trait;
+use serde_json::json;
+use std::sync::Arc;
+
+/// Outbound A2A client tool — discovers remote agents and sends/retrieves tasks.
+pub struct A2aTool {
+    security: Arc<SecurityPolicy>,
+    timeout_secs: u64,
+}
+
+impl A2aTool {
+    pub fn new(security: Arc<SecurityPolicy>, timeout_secs: u64) -> Self {
+        Self {
+            security,
+            timeout_secs,
+        }
+    }
+
+    fn build_client(&self) -> anyhow::Result<reqwest::Client> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(self.timeout_secs))
+            .build()?;
+        Ok(client)
+    }
+
+    fn validate_url(url: &str) -> anyhow::Result<reqwest::Url> {
+        let parsed = reqwest::Url::parse(url)?;
+        match parsed.scheme() {
+            "http" | "https" => Ok(parsed),
+            scheme => anyhow::bail!("Unsupported URL scheme: {scheme} (only http/https allowed)"),
+        }
+    }
+
+    async fn action_discover(
+        &self,
+        url: &str,
+        bearer_token: Option<&str>,
+    ) -> anyhow::Result<ToolResult> {
+        let base = Self::validate_url(url)?;
+        let card_url = base.join("/.well-known/agent-card.json")?;
+        let client = self.build_client()?;
+
+        let mut req = client.get(card_url);
+        if let Some(token) = bearer_token {
+            req = req.bearer_auth(token);
+        }
+
+        let resp = req.send().await?;
+        let status = resp.status();
+        let body = resp.text().await?;
+
+        if status.is_success() {
+            Ok(ToolResult {
+                success: true,
+                output: body,
+                error: None,
+            })
+        } else {
+            Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("HTTP {status}: {body}")),
+            })
+        }
+    }
+
+    async fn action_send(
+        &self,
+        url: &str,
+        bearer_token: Option<&str>,
+        message: &str,
+    ) -> anyhow::Result<ToolResult> {
+        let base = Self::validate_url(url)?;
+        let rpc_url = base.join("/a2a")?;
+        let client = self.build_client()?;
+        let request_id = uuid::Uuid::new_v4().to_string();
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tasks/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{ "type": "text", "text": message }]
+                }
+            }
+        });
+
+        let mut req = client.post(rpc_url).json(&body);
+        if let Some(token) = bearer_token {
+            req = req.bearer_auth(token);
+        }
+
+        let resp = req.send().await?;
+        let status = resp.status();
+        let resp_body = resp.text().await?;
+
+        if status.is_success() {
+            Ok(ToolResult {
+                success: true,
+                output: resp_body,
+                error: None,
+            })
+        } else {
+            Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("HTTP {status}: {resp_body}")),
+            })
+        }
+    }
+
+    async fn action_get_task(
+        &self,
+        url: &str,
+        bearer_token: Option<&str>,
+        task_id: &str,
+    ) -> anyhow::Result<serde_json::Value> {
+        let base = Self::validate_url(url)?;
+        let rpc_url = base.join("/a2a")?;
+        let client = self.build_client()?;
+        let request_id = uuid::Uuid::new_v4().to_string();
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tasks/get",
+            "params": { "id": task_id }
+        });
+
+        let mut req = client.post(rpc_url).json(&body);
+        if let Some(token) = bearer_token {
+            req = req.bearer_auth(token);
+        }
+
+        let resp = req.send().await?;
+        let status = resp.status();
+        let resp_body = resp.text().await?;
+
+        if status.is_success() {
+            let parsed: serde_json::Value = serde_json::from_str(&resp_body)?;
+            Ok(parsed)
+        } else {
+            anyhow::bail!("HTTP {status}: {resp_body}");
+        }
+    }
+
+    async fn action_status(
+        &self,
+        url: &str,
+        bearer_token: Option<&str>,
+        task_id: &str,
+    ) -> anyhow::Result<ToolResult> {
+        match self.action_get_task(url, bearer_token, task_id).await {
+            Ok(resp) => Ok(ToolResult {
+                success: true,
+                output: serde_json::to_string_pretty(&resp)?,
+                error: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+
+    async fn action_result(
+        &self,
+        url: &str,
+        bearer_token: Option<&str>,
+        task_id: &str,
+    ) -> anyhow::Result<ToolResult> {
+        match self.action_get_task(url, bearer_token, task_id).await {
+            Ok(resp) => {
+                // Extract artifacts from the task response
+                let artifacts = resp
+                    .pointer("/result/artifacts")
+                    .or_else(|| resp.pointer("/artifacts"))
+                    .cloned()
+                    .unwrap_or(json!([]));
+                Ok(ToolResult {
+                    success: true,
+                    output: serde_json::to_string_pretty(&artifacts)?,
+                    error: None,
+                })
+            }
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for A2aTool {
+    fn name(&self) -> &str {
+        "a2a"
+    }
+
+    fn description(&self) -> &str {
+        "Communicate with remote agents via the A2A (Agent-to-Agent) protocol. \
+         Supports four actions: 'discover' to fetch a remote agent's capability card, \
+         'send' to dispatch a task message, 'status' to check task progress, and \
+         'result' to retrieve task output artifacts."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["discover", "send", "status", "result"],
+                    "description": "A2A operation to perform"
+                },
+                "url": {
+                    "type": "string",
+                    "description": "Base URL of the remote agent (e.g. http://host:port)"
+                },
+                "bearer_token": {
+                    "type": "string",
+                    "description": "Bearer token for authentication with the remote agent"
+                },
+                "task_id": {
+                    "type": "string",
+                    "description": "Task ID (required for status/result actions)"
+                },
+                "message": {
+                    "type": "string",
+                    "description": "Message to send to the remote agent (required for send action)"
+                }
+            },
+            "required": ["action", "url"]
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        self.security.record_action();
+
+        let action = args
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let url = args
+            .get("url")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let bearer_token = args
+            .get("bearer_token")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let task_id = args
+            .get("task_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let message = args
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        if url.is_empty() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Missing required parameter: url".into()),
+            });
+        }
+
+        match action.as_str() {
+            "discover" => self.action_discover(&url, bearer_token.as_deref()).await,
+            "send" => {
+                if message.is_empty() {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some("Missing required parameter: message".into()),
+                    });
+                }
+                self.action_send(&url, bearer_token.as_deref(), &message)
+                    .await
+            }
+            "status" => {
+                if task_id.is_empty() {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some("Missing required parameter: task_id".into()),
+                    });
+                }
+                self.action_status(&url, bearer_token.as_deref(), &task_id)
+                    .await
+            }
+            "result" => {
+                if task_id.is_empty() {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some("Missing required parameter: task_id".into()),
+                    });
+                }
+                self.action_result(&url, bearer_token.as_deref(), &task_id)
+                    .await
+            }
+            other => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Unknown action: '{other}'. Valid actions: discover, send, status, result"
+                )),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::SecurityPolicy;
+
+    fn test_tool() -> A2aTool {
+        let security = Arc::new(SecurityPolicy::default());
+        A2aTool::new(security, 30)
+    }
+
+    #[test]
+    fn tool_metadata() {
+        let tool = test_tool();
+        assert_eq!(tool.name(), "a2a");
+        assert!(!tool.description().is_empty());
+
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["action"].is_object());
+        assert!(schema["properties"]["url"].is_object());
+
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("action")));
+        assert!(required.contains(&json!("url")));
+    }
+
+    #[test]
+    fn validate_url_accepts_http() {
+        assert!(A2aTool::validate_url("http://localhost:8080").is_ok());
+        assert!(A2aTool::validate_url("https://agent.example.com").is_ok());
+    }
+
+    #[test]
+    fn validate_url_rejects_non_http() {
+        assert!(A2aTool::validate_url("ftp://host").is_err());
+        assert!(A2aTool::validate_url("file:///etc/passwd").is_err());
+    }
+
+    #[tokio::test]
+    async fn missing_url_returns_error() {
+        let tool = test_tool();
+        let result = tool.execute(json!({"action": "discover"})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_deref().unwrap().contains("url"));
+    }
+
+    #[tokio::test]
+    async fn unknown_action_returns_error() {
+        let tool = test_tool();
+        let result = tool
+            .execute(json!({"action": "invalid", "url": "http://localhost"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_deref().unwrap().contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn send_missing_message_returns_error() {
+        let tool = test_tool();
+        let result = tool
+            .execute(json!({"action": "send", "url": "http://localhost"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_deref().unwrap().contains("message"));
+    }
+
+    #[tokio::test]
+    async fn status_missing_task_id_returns_error() {
+        let tool = test_tool();
+        let result = tool
+            .execute(json!({"action": "status", "url": "http://localhost"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_deref().unwrap().contains("task_id"));
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -15,6 +15,7 @@
 //! To add a new tool, implement [`Tool`] in a new submodule and register it in
 //! [`all_tools_with_runtime`]. See `AGENTS.md` §7.3 for the full change playbook.
 
+pub mod a2a;
 pub mod backup_tool;
 pub mod browser;
 pub mod browser_delegate;
@@ -78,6 +79,7 @@ pub mod web_fetch;
 pub mod web_search_tool;
 pub mod workspace_tool;
 
+pub use a2a::A2aTool;
 pub use backup_tool::BackupTool;
 pub use browser::{BrowserTool, ComputerUseConfig};
 #[allow(unused_imports)]
@@ -371,6 +373,14 @@ pub fn all_tools_with_runtime(
             web_fetch_config.blocked_domains.clone(),
             web_fetch_config.max_response_size,
             web_fetch_config.timeout_secs,
+        )));
+    }
+
+    // A2A (Agent-to-Agent) protocol client tool
+    if root_config.a2a.enabled {
+        tool_arcs.push(Arc::new(A2aTool::new(
+            security.clone(),
+            root_config.a2a.timeout_secs,
         )));
     }
 


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: ZeroClaw agents cannot be discovered by or communicate with external agents across different hosts/frameworks — multi-agent is intra-instance only.
- Why it matters: Teams must route inter-agent communication through third-party channels (Telegram, etc.) instead of direct agent-to-agent connections. No standardized discovery or task delegation exists.
- What changed: Added native A2A protocol support ([Agent2Agent](https://github.com/a2aproject/A2A), Linux Foundation open standard) with an outbound client tool (`src/tools/a2a.rs`), inbound JSON-RPC 2.0 server endpoints (`src/gateway/a2a.rs`), auto-generated agent card, and `A2aConfig` schema.
- What did **not** change (scope boundary): No SSE streaming, webhook push, mTLS/OAuth, agent registry/DNS discovery, or ACP/ANP. Core agent loop is unchanged — inbound tasks route through the existing `process_message` pipeline.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: M`
- Scope labels: `gateway`, `tool`, `config`, `onboard`
- Module labels: `tool: a2a`, `gateway: a2a`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes zeroclaw-labs/zeroclaw#3566
- Related zeroclaw-labs/zeroclaw#218, zeroclaw-labs/zeroclaw#264, zeroclaw-labs/zeroclaw#1668, zeroclaw-labs/zeroclaw#2913
- Depends on # (if stacked): N/A
- Supersedes # (if replacing older PR): N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A — no superseded PRs.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check    # ✅ clean
cargo clippy --all-targets -- -D warnings  # ✅ clean
cargo test                    # ✅ 4083 passed, 2 pre-existing failures (service::tests), 11 new A2A tests pass
```

- Evidence provided: 11 unit tests covering tool metadata, URL validation, action dispatch errors, agent card generation (defaults + custom), JSON-RPC error formatting, and task store lifecycle.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? Yes
- New external network calls? Yes
- Secrets/tokens handling changed? Yes
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation:
  - **Outbound HTTP**: A2A tool sends requests to remote agents via reqwest. URLs validated (HTTP/HTTPS only). Bearer tokens are per-call parameters, not logged in tool output.
  - **Inbound endpoints**: `GET /.well-known/agent-card.json` (unauthenticated discovery — metadata only, no secrets). `POST /a2a` (authenticated — requires bearer token via PairingGuard or dedicated `a2a.bearer_token`).
  - **Bearer token config**: `a2a.bearer_token` stored in config.toml (same treatment as `api_key`). Falls back to gateway pairing tokens when unset.
  - **Localhost by default**: Inherits gateway `host: 127.0.0.1`. Public bind requires explicit `gateway.allow_public_bind = true`.
  - **Fully opt-in**: Disabled by default (`a2a.enabled = false`). Zero attack surface when disabled.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No PII in agent cards or task responses. Bearer tokens never included in tool output.
- Neutral wording confirmation: Yes — uses ZeroClaw/project-native labels throughout.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional `[a2a]` config section with `#[serde(default)]`
- Migration needed? No — existing configs parse unchanged, feature is disabled by default.
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — no docs or user-facing wording changes.
- If `Yes`, locale navigation parity updated? N/A
- If `Yes`, localized runtime-contract docs updated? N/A
- If `Yes`, Vietnamese canonical docs synced? N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: No user-facing wording changes in this PR.

## Human Verification (required)

- Verified scenarios: Compilation, formatting, clippy, all 11 new unit tests, no regressions in 4083 existing tests.
- Edge cases checked: Missing parameters (url, message, task_id), unknown actions, invalid URL schemes (ftp, file), empty bearer tokens, disabled feature returning 404.
- What was not verified: End-to-end inter-instance task exchange (requires two running instances). Manual gateway startup with `[a2a] enabled = true`.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Gateway (2 new routes), tool registry (1 new conditional tool), config schema (1 new section), onboard wizard (field addition).
- Potential unintended effects: None — feature is fully opt-in and disabled by default. Routes return 404 when disabled. No changes to existing handler behavior.
- Guardrails/monitoring for early detection: A2A endpoints behind `a2a.enabled` config flag. Inbound task processing reuses existing `process_message` pipeline with standard observability.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (Opus 4.6)
- Workflow/plan summary: Explored codebase patterns (Tool trait, gateway routing, config schema), designed implementation following HttpRequestTool and GitOperationsTool patterns, implemented 2 new files + 5 modifications.
- Verification focus: Compilation, clippy, formatting, unit tests for all new code paths.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: Revert commit or set `[a2a] enabled = false` in config.toml.
- Feature flags or config toggles: `a2a.enabled` (default: `false`) gates both tool registration and server endpoints.
- Observable failure symptoms: A2A routes returning errors, tool execution failures visible in agent logs.

## Risks and Mitigations

- Risk: Increased attack surface from new HTTP endpoints.
  - Mitigation: Localhost-only by default, bearer token auth required on task endpoint, agent card is metadata-only, feature fully disabled by default.
- Risk: Inbound tasks consuming unbounded resources.
  - Mitigation: Tasks processed through existing `process_message` pipeline which enforces `max_tool_iterations`, `max_context_tokens`, and rate limiting.
- Risk: In-memory task store unbounded growth.
  - Mitigation: V1 acceptable — task store is per-gateway-lifetime (cleared on restart). TTL/LRU eviction can follow.