### PR TITLE
chore: simplify PR template — 115 → 46 lines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,114 +1,45 @@
-## Summary
+<!--
+  Thanks for contributing to Hrafn!
+  Fill in what's relevant, delete what's not.
+  Small PRs don't need every section.
+-->
 
-Describe this PR in 2-5 bullets:
+## What
 
-- Base branch target (`master` for all contributions):
-- Problem:
-- Why it matters:
-- What changed:
-- What did **not** change (scope boundary):
+<!-- What changed and why? Link the issue. -->
 
-## Label Snapshot (required)
+Closes #
 
-- Risk label (`risk: low|medium|high`):
-- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
-- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
-- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):
-- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
-- If any auto-label is incorrect, note requested correction:
+## How to test
 
-## Change Metadata
-
-- Change type (`bug|feature|refactor|docs|security|chore`):
-- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):
-
-## Linked Issue
-
-- Closes #
-- Related #
-- Depends on # (if stacked)
-- Supersedes # (if replacing older PR)
-
-## Supersede Attribution (required when `Supersedes #` is used)
-
-- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
-- Integrated scope by source PR (what was materially carried forward):
-- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
-- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
-- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)
-
-## Validation Evidence (required)
-
-Commands and result summary:
+<!-- Steps or commands so a reviewer can verify. -->
 
 ```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings
-cargo test
+cargo test -- relevant_test_name
 ```
 
-- Evidence provided (test/log/trace/screenshot/perf):
-- If any command is intentionally skipped, explain why:
+## Breaking changes
 
-## Security Impact (required)
+<!-- Delete this section if none. -->
+<!-- Config key renamed? CLI flag changed? Trait signature updated? -->
 
-- New permissions/capabilities? (`Yes/No`)
-- New external network calls? (`Yes/No`)
-- Secrets/tokens handling changed? (`Yes/No`)
-- File system access scope changed? (`Yes/No`)
-- If any `Yes`, describe risk and mitigation:
+- [ ] This PR includes breaking changes
 
-## Privacy and Data Hygiene (required)
+**Migration:** <!-- How do users update? -->
 
-- Data-hygiene status (`pass|needs-follow-up`):
-- Redaction/anonymization notes:
-- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):
+## Security
 
-## Compatibility / Migration
+<!-- Delete this section if not security-relevant. -->
 
-- Backward compatible? (`Yes/No`)
-- Config/env changes? (`Yes/No`)
-- Migration needed? (`Yes/No`)
-- If yes, exact upgrade steps:
+- [ ] New network calls or endpoints
+- [ ] Secrets/tokens handling changed
+- [ ] File system access scope changed
+- [ ] SSRF / input validation implications
 
-## i18n Follow-Through (required when docs or user-facing wording changes)
+**Risk and mitigation:** <!-- Brief description -->
 
-- i18n follow-through triggered? (`Yes/No`)
-- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
-- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
-- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
-- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:
+## Checklist
 
-## Human Verification (required)
-
-What was personally validated beyond CI:
-
-- Verified scenarios:
-- Edge cases checked:
-- What was not verified:
-
-## Side Effects / Blast Radius (required)
-
-- Affected subsystems/workflows:
-- Potential unintended effects:
-- Guardrails/monitoring for early detection:
-
-## Agent Collaboration Notes (recommended)
-
-- Agent tools used (if any):
-- Workflow/plan summary (if any):
-- Verification focus:
-- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):
-
-## Rollback Plan (required)
-
-- Fast rollback command/path:
-- Feature flags or config toggles (if any):
-- Observable failure symptoms:
-
-## Risks and Mitigations
-
-List real risks in this PR (or write `None`).
-
-- Risk:
-  - Mitigation:
+- [ ] `cargo fmt && cargo clippy -D warnings` passes
+- [ ] Tests pass, new code has tests
+- [ ] I can explain every line in this PR


### PR DESCRIPTION
## What

The existing PR template had 15 required sections (i18n follow-through, supersede attribution, rollback plans, privacy/data hygiene, agent collaboration notes, etc.). Contributors were deleting most of it on every PR.

Replace with a focused template: **What / How to test / Breaking changes / Security / Checklist**. Delete what doesn't apply.

115 lines → 46 lines. -60%.

## How to test

Open a new PR draft and verify the template renders correctly.

## Checklist

- [x] I can explain every line in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)