### PR TITLE
fix(security): prevent panics on malformed user input

### DIFF
--- a/src/channels/imessage.rs
+++ b/src/channels/imessage.rs
@@ -20,10 +20,6 @@ fn extract_text_from_attributed_body(blob: &[u8]) -> Option<String> {
     let marker_pos = blob.windows(2).position(|w| w == [0x01, 0x2B])?;
     let rest = blob.get(marker_pos + 2..)?;
 
-    if rest.is_empty() {
-        return None;
-    }
-
     // Read variable-length prefix immediately after the marker.
     // The length determines text extent — we do NOT scan for an end marker,
     // because byte pairs like [0x86, 0x84] can appear inside valid UTF-8
@@ -33,20 +29,21 @@ fn extract_text_from_attributed_body(blob: &[u8]) -> Option<String> {
     //   0x81      => next 2 bytes are little-endian u16 length
     //   0x82      => next 4 bytes are little-endian u32 length
     //   0x80, 0x83+ are not observed in iMessage typedstreams; reject gracefully.
-    let (length, text_start) = match rest[0] {
-        0x81 if rest.len() >= 3 => {
-            let len = u16::from_le_bytes([rest[1], rest[2]]) as usize;
-            (len, 3)
+    let (length, text_start): (usize, usize) = match rest.first()? {
+        0x81 => {
+            let bytes: [u8; 2] = rest.get(1..3)?.try_into().ok()?;
+            (u16::from_le_bytes(bytes) as usize, 3)
         }
-        0x82 if rest.len() >= 5 => {
-            let len = u32::from_le_bytes([rest[1], rest[2], rest[3], rest[4]]) as usize;
-            (len, 5)
+        0x82 => {
+            let bytes: [u8; 4] = rest.get(1..5)?.try_into().ok()?;
+            (u32::from_le_bytes(bytes) as usize, 5)
         }
-        b if b <= 0x7F => (b as usize, 1),
+        &b if b <= 0x7F => (b as usize, 1),
         _ => return None,
     };
 
-    let text_bytes = rest.get(text_start..text_start + length)?;
+    let end = text_start.checked_add(length)?;
+    let text_bytes = rest.get(text_start..end)?;
     std::str::from_utf8(text_bytes).ok().map(str::to_owned)
 }
 

--- a/src/channels/voice_wake.rs
+++ b/src/channels/voice_wake.rs
@@ -281,13 +281,30 @@ pub fn compute_rms_energy(samples: &[f32]) -> f32 {
 /// Encode raw f32 PCM samples as a WAV byte buffer (16-bit PCM).
 ///
 /// This produces a minimal valid WAV file that Whisper-compatible APIs accept.
+/// Returns an empty `Vec` if the sample buffer is too large for WAV (>2 GB data).
 pub fn encode_wav_from_f32(samples: &[f32], sample_rate: u32, channels: u16) -> Vec<u8> {
     let bits_per_sample: u16 = 16;
-    let byte_rate = u32::from(channels) * sample_rate * u32::from(bits_per_sample) / 8;
+    let byte_rate = u32::from(channels)
+        .saturating_mul(sample_rate)
+        .saturating_mul(u32::from(bits_per_sample))
+        / 8;
     let block_align = channels * bits_per_sample / 8;
-    #[allow(clippy::cast_possible_truncation)]
-    let data_len = (samples.len() * 2) as u32; // 16-bit = 2 bytes per sample; max ~25 MB
-    let file_len = 36 + data_len;
+
+    // Guard against overflow: each sample is 2 bytes, and data_len must fit u32.
+    let Some(data_len) = (samples.len())
+        .checked_mul(2)
+        .and_then(|n| u32::try_from(n).ok())
+    else {
+        tracing::warn!(
+            sample_count = samples.len(),
+            "WAV encode: sample buffer too large, skipping"
+        );
+        return Vec::new();
+    };
+    let Some(file_len) = 36u32.checked_add(data_len) else {
+        tracing::warn!("WAV encode: file size overflow, skipping");
+        return Vec::new();
+    };
 
     let mut buf = Vec::with_capacity(file_len as usize + 8);
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1220,12 +1220,16 @@ fn create_provider_with_url_and_options(
             key,
             AuthStyle::Bearer,
         ))),
-        name if moonshot_base_url(name).is_some() => Ok(compat(OpenAiCompatibleProvider::new(
-            "Moonshot",
-            moonshot_base_url(name).expect("checked in guard"),
-            key,
-            AuthStyle::Bearer,
-        ))),
+        name if moonshot_base_url(name).is_some() => {
+            let url =
+                moonshot_base_url(name).ok_or_else(|| anyhow::anyhow!("unreachable: guard"))?;
+            Ok(compat(OpenAiCompatibleProvider::new(
+                "Moonshot",
+                url,
+                key,
+                AuthStyle::Bearer,
+            )))
+        }
         "kimi-code" | "kimi_coding" | "kimi_for_coding" => {
             Ok(compat(OpenAiCompatibleProvider::new_with_user_agent(
                 "Kimi Code",
@@ -1253,28 +1257,36 @@ fn create_provider_with_url_and_options(
             key,
             AuthStyle::Bearer,
         ))),
-        name if zai_base_url(name).is_some() => Ok(compat(OpenAiCompatibleProvider::new(
-            "Z.AI",
-            zai_base_url(name).expect("checked in guard"),
-            key,
-            AuthStyle::ZhipuJwt,
-        ))),
-        name if glm_base_url(name).is_some() => {
-            Ok(compat(OpenAiCompatibleProvider::new_no_responses_fallback(
-                "GLM",
-                glm_base_url(name).expect("checked in guard"),
+        name if zai_base_url(name).is_some() => {
+            let url = zai_base_url(name).ok_or_else(|| anyhow::anyhow!("unreachable: guard"))?;
+            Ok(compat(OpenAiCompatibleProvider::new(
+                "Z.AI",
+                url,
                 key,
                 AuthStyle::ZhipuJwt,
             )))
         }
-        name if minimax_base_url(name).is_some() => Ok(compat(
-            OpenAiCompatibleProvider::new_merge_system_into_user(
-                "MiniMax",
-                minimax_base_url(name).expect("checked in guard"),
+        name if glm_base_url(name).is_some() => {
+            let url = glm_base_url(name).ok_or_else(|| anyhow::anyhow!("unreachable: guard"))?;
+            Ok(compat(OpenAiCompatibleProvider::new_no_responses_fallback(
+                "GLM",
+                url,
                 key,
-                AuthStyle::Bearer,
-            ),
-        )),
+                AuthStyle::ZhipuJwt,
+            )))
+        }
+        name if minimax_base_url(name).is_some() => {
+            let url =
+                minimax_base_url(name).ok_or_else(|| anyhow::anyhow!("unreachable: guard"))?;
+            Ok(compat(
+                OpenAiCompatibleProvider::new_merge_system_into_user(
+                    "MiniMax",
+                    url,
+                    key,
+                    AuthStyle::Bearer,
+                ),
+            ))
+        }
         "azure_openai" | "azure-openai" | "azure" => {
             let resource = std::env::var("AZURE_OPENAI_RESOURCE")
                 .unwrap_or_else(|_| "my-resource".to_string());
@@ -1348,9 +1360,10 @@ fn create_provider_with_url_and_options(
             ),
         )),
         name if qwen_base_url(name).is_some() => {
+            let url = qwen_base_url(name).ok_or_else(|| anyhow::anyhow!("unreachable: guard"))?;
             Ok(compat(OpenAiCompatibleProvider::new_with_vision(
                 "Qwen",
-                qwen_base_url(name).expect("checked in guard"),
+                url,
                 key,
                 AuthStyle::Bearer,
                 true,


### PR DESCRIPTION
## Summary
- **iMessage binary parsing**: Replace raw array indexing with `rest.get()` + `try_into()` so short/malformed typedstream blobs return `None` instead of panicking. Also guard `text_start + length` against arithmetic overflow.
- **Provider URL matching**: Replace `.expect("checked in guard")` with `.ok_or_else()` error propagation in 5 match arms (Moonshot, Z.AI, GLM, MiniMax, Qwen), eliminating panic paths on the double-call pattern.
- **WAV encoding**: Use `checked_mul` / `checked_add` for sample-to-byte size calculations; return an empty buffer with a warning instead of panicking on overflow.

Closes #9

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — all 5899 tests pass
- [ ] Manual: feed a truncated iMessage blob (< 3 bytes after marker) to `extract_text_from_attributed_body` and verify `None` return
- [ ] Manual: verify provider creation still works for moonshot/zai/glm/minimax/qwen aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)