### PR TITLE
fix(security): close OTP file TOCTOU, validate icacls username, fix audit log race

### DIFF
--- a/src/security/audit.rs
+++ b/src/security/audit.rs
@@ -283,25 +283,24 @@ impl AuditLogger {
             return Ok(());
         }
 
-        // Check log size and rotate if needed
+        // Hold the chain lock across rotation, chain-state update, and file
+        // write to prevent a race where two concurrent callers both rotate or
+        // interleave writes with inconsistent sequence numbers.
+        let mut chained = event.clone();
+        let mut state = self.chain.lock();
+
+        // Check log size and rotate if needed (under lock)
         self.rotate_if_needed()?;
 
-        // Populate chain fields under the lock
-        let mut chained = event.clone();
-        {
-            let mut state = self.chain.lock();
-            chained.sequence = state.sequence;
-            chained.prev_hash = state.prev_hash.clone();
-            chained.entry_hash = compute_entry_hash(&state.prev_hash, &chained);
+        // Populate chain fields
+        chained.sequence = state.sequence;
+        chained.prev_hash = state.prev_hash.clone();
+        chained.entry_hash = compute_entry_hash(&state.prev_hash, &chained);
 
-            // Compute signature if sign_events enabled
-            chained.signature = self.compute_signature(&chained.entry_hash)?;
+        // Compute signature if sign_events enabled
+        chained.signature = self.compute_signature(&chained.entry_hash)?;
 
-            state.prev_hash = chained.entry_hash.clone();
-            state.sequence += 1;
-        }
-
-        // Serialize and write
+        // Serialize and write (under lock)
         let line = serde_json::to_string(&chained)?;
         let mut file = OpenOptions::new()
             .create(true)
@@ -310,6 +309,10 @@ impl AuditLogger {
 
         writeln!(file, "{}", line)?;
         file.sync_all()?;
+
+        // Update chain state only after successful write
+        state.prev_hash = chained.entry_hash.clone();
+        state.sequence += 1;
 
         Ok(())
     }

--- a/src/security/otp.rs
+++ b/src/security/otp.rs
@@ -126,23 +126,48 @@ pub fn secret_file_path(hrafn_dir: &Path) -> PathBuf {
 }
 
 fn write_secret_file(path: &Path, value: &str) -> Result<()> {
+    use std::io::Write;
+
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create directory {}", parent.display()))?;
     }
 
     let temp_path = path.with_extension(format!("tmp-{}", uuid::Uuid::new_v4()));
-    fs::write(&temp_path, value).with_context(|| {
-        format!(
-            "Failed to write temporary OTP secret {}",
-            temp_path.display()
-        )
-    })?;
 
+    // On Unix, create the file with restrictive permissions from the start to
+    // avoid a TOCTOU window where the file is world-readable between creation
+    // and a subsequent chmod.
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o600));
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temp_path)
+            .with_context(|| {
+                format!(
+                    "Failed to create temporary OTP secret {}",
+                    temp_path.display()
+                )
+            })?;
+        file.write_all(value.as_bytes()).with_context(|| {
+            format!(
+                "Failed to write temporary OTP secret {}",
+                temp_path.display()
+            )
+        })?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::write(&temp_path, value).with_context(|| {
+            format!(
+                "Failed to write temporary OTP secret {}",
+                temp_path.display()
+            )
+        })?;
     }
 
     fs::rename(&temp_path, path).with_context(|| {

--- a/src/security/secrets.rs
+++ b/src/security/secrets.rs
@@ -284,11 +284,23 @@ fn hex_encode(data: &[u8]) -> String {
     s
 }
 
-/// Build the `/grant` argument for `icacls` using a normalized username.
-/// Returns `None` when the username is empty or whitespace-only.
+/// Build the `/grant` argument for `icacls` using a validated username.
+/// Returns `None` when the username is empty, whitespace-only, or contains
+/// characters that could confuse `icacls` argument parsing.
+///
+/// Only allows alphanumeric characters, underscores, hyphens, dots, backslashes
+/// (for `DOMAIN\User`), and spaces (for display names). Rejects anything else
+/// (e.g. `:`, `/`, `"`) to prevent argument injection.
 fn build_windows_icacls_grant_arg(username: &str) -> Option<String> {
     let normalized = username.trim();
     if normalized.is_empty() {
+        return None;
+    }
+    // Reject usernames with characters that could confuse icacls parsing.
+    let is_safe = normalized
+        .chars()
+        .all(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | '.' | '\\' | ' '));
+    if !is_safe {
         return None;
     }
     Some(format!("{normalized}:F"))
@@ -808,6 +820,18 @@ mod tests {
             build_windows_icacls_grant_arg("DOMAIN\\svc-user"),
             Some("DOMAIN\\svc-user:F".to_string())
         );
+    }
+
+    #[test]
+    fn windows_icacls_grant_arg_rejects_adversarial_usernames() {
+        // Colon could confuse icacls permission parsing (e.g. "evil:R")
+        assert_eq!(build_windows_icacls_grant_arg("evil:R"), None);
+        // Slash could be misinterpreted as an icacls flag
+        assert_eq!(build_windows_icacls_grant_arg("user/grant"), None);
+        // Quotes could break argument parsing
+        assert_eq!(build_windows_icacls_grant_arg("user\"name"), None);
+        // Parentheses used in icacls permission syntax
+        assert_eq!(build_windows_icacls_grant_arg("user(OI)"), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Three hardening fixes in the security module:

1. **OTP TOCTOU** (`otp.rs`): Use `OpenOptions::new().create_new(true).mode(0o600)` on Unix to set restrictive permissions atomically at file creation, eliminating the window where the temp file is world-readable
2. **Windows icacls injection** (`secrets.rs`): Validate username matches `[a-zA-Z0-9_\-.\\ ]` before passing to icacls, rejecting adversarial usernames with `:`, `/`, `"` etc.
3. **Audit log rotation race** (`audit.rs`): Hold the chain lock across the entire log operation (rotation check, chain state, file write, state update) to prevent double-rotation and interleaved writes

Closes #15

## How to test

```bash
cargo test -- security
cargo test -- otp
cargo test -- audit
cargo clippy --all-targets -- -D warnings
```

## Security

- [x] Secrets/tokens handling changed
- [x] File system access scope changed

**Risk and mitigation:** All three fixes tighten existing security boundaries. OTP fix is Unix-only with Windows fallback. icacls validation is conservative (allowlist approach). Audit lock scope increase may slightly reduce write throughput but ensures correctness.

## Checklist

- [x] `cargo fmt && cargo clippy -D warnings` passes
- [x] Tests pass, new code has tests
- [x] I can explain every line in this PR