### PR TITLE
fix(ci): use GITHUB_TOKEN for release creation

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -391,7 +391,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.version.outputs.tag }}
         run: |
           gh release create "$TAG" release-assets/* \

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -426,7 +426,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           gh release create "$TAG" release-assets/* \


### PR DESCRIPTION
## Summary

- Replace `secrets.RELEASE_TOKEN` with `secrets.GITHUB_TOKEN` in the "Create GitHub Release" step of both `release-beta-on-push.yml` and `release-stable-manual.yml`.
- `RELEASE_TOKEN` is not configured as a repo secret, causing the release step to fail with an empty token.
- Both workflows already declare `permissions: contents: write`, which grants `GITHUB_TOKEN` sufficient scope for `gh release create`.

## Test plan

- [ ] Trigger a beta release by pushing to master and verify the "Create GitHub Release" step succeeds.
- [ ] Trigger a stable release via workflow_dispatch and verify the release is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)