### PR TITLE
docs: add BSL 1.1 licensing notice for muninndb feature gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,5 @@ Hrafn originated as a fork of [ZeroClaw](https://github.com/zeroclaw-labs/zerocl
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE). You retain copyright of your contributions.
+
+**`memory-muninndb` feature gate:** Enabling this feature pulls in [MuninnDB](https://github.com/5queezer/muninndb), which is licensed under BSL 1.1 (not open source) and patent pending (U.S. Provisional Application No. 63/991,402). Commercial use of MuninnDB requires a separate license. See [muninndb.com](https://muninndb.com) for details.


### PR DESCRIPTION
## Summary

- Adds a licensing notice to the README License section clarifying that the `memory-muninndb` feature gate pulls in MuninnDB (BSL 1.1, patent pending)
- Notes that commercial use requires a separate license and links to muninndb.com

## Test plan

- [x] Verify README renders correctly
- [x] No other files modified

https://claude.ai/code/session_01GEfEvTehdZD3GeAeFeVkxY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with a license notice clarifying that enabling the memory-muninndb feature includes a component requiring a separate commercial license agreement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->