### PR TITLE
fix(memory): filter [Memory context] blobs from auto-save

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -118,6 +118,7 @@ pub fn should_skip_autosave_content(content: &str) -> bool {
     lowered.starts_with("[cron:")
         || lowered.starts_with("[heartbeat task")
         || lowered.starts_with("[distilled_")
+        || lowered.starts_with("[memory context]")
         || lowered.contains("distilled_index_sig:")
 }
 
@@ -485,6 +486,9 @@ mod tests {
         ));
         assert!(should_skip_autosave_content(
             "[Heartbeat Task | high] Execute scheduled patrol"
+        ));
+        assert!(should_skip_autosave_content(
+            "[Memory context]\n- entry1\n- entry2"
         ));
         assert!(!should_skip_autosave_content(
             "User prefers concise answers."


### PR DESCRIPTION
## Summary

- Prevents `[Memory context]` recall blobs from being re-ingested by auto-save, which causes exponential DB growth (memory snowball)
- One-line addition to `should_skip_autosave_content()` filter + test assertion

## Upstream reference

- Original issue: zeroclaw-labs/zeroclaw#4916 by @amreshtech
- Status: Open, no maintainer response, no fix PR upstream
- Confirmed by second user (@NeonHarbor22) on v0.6.5 — `brain.db` grew to 1.8 GB with a single 728 MB row
- Changes from original: Hrafn already had the filter infrastructure (`should_skip_autosave_content`); this adds the missing `[memory context]` prefix to the deny list

## Risk

Low — adds one filter condition to an existing synthetic-content guard. No behavior change for real user memories.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test autosave_content_filter` — new assertion passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated autosave content filtering to properly skip entries containing memory context markers, with corresponding test coverage added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->