### PR TITLE
ci: add aarch64-unknown-linux-musl release target

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -195,6 +195,12 @@ jobs:
             linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             linker: aarch64-linux-gnu-gcc
           - os: ubuntu-22.04
+            target: aarch64-unknown-linux-musl
+            artifact: hrafn
+            ext: tar.gz
+            use_cross: true
+            features: channel-lark,whatsapp-web  # matrix-sdk hits recursion limit under musl
+          - os: ubuntu-22.04
             target: armv7-unknown-linux-gnueabihf
             artifact: hrafn
             ext: tar.gz
@@ -247,7 +253,12 @@ jobs:
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
           fi
-          cargo build --release --locked --features "${{ matrix.features || env.RELEASE_CARGO_FEATURES }}" --target ${{ matrix.target }}
+          BUILD_CMD="cargo"
+          if [ "${{ matrix.use_cross || 'false' }}" = "true" ]; then
+            cargo install cross --locked
+            BUILD_CMD="cross"
+          fi
+          $BUILD_CMD build --release --locked --features "${{ matrix.features || env.RELEASE_CARGO_FEATURES }}" --target ${{ matrix.target }}
 
       - name: Check binary size
         shell: bash
@@ -352,6 +363,7 @@ jobs:
           required_assets=(
             "hrafn-x86_64-unknown-linux-gnu.tar.gz"
             "hrafn-aarch64-unknown-linux-gnu.tar.gz"
+            "hrafn-aarch64-unknown-linux-musl.tar.gz"
             "hrafn-armv7-unknown-linux-gnueabihf.tar.gz"
             "hrafn-aarch64-apple-darwin.tar.gz"
             "hrafn-aarch64-linux-android.tar.gz"

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -196,6 +196,12 @@ jobs:
             linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             linker: aarch64-linux-gnu-gcc
           - os: ubuntu-22.04
+            target: aarch64-unknown-linux-musl
+            artifact: hrafn
+            ext: tar.gz
+            use_cross: true
+            cargo_features: channel-lark,whatsapp-web  # matrix-sdk hits recursion limit under musl
+          - os: ubuntu-22.04
             target: armv7-unknown-linux-gnueabihf
             artifact: hrafn
             ext: tar.gz
@@ -267,12 +273,17 @@ jobs:
             export CFLAGS_arm_unknown_linux_gnueabihf="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
             export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C target-feature=-neon"
           fi
+          BUILD_CMD="cargo"
+          if [ "${{ matrix.use_cross || 'false' }}" = "true" ]; then
+            cargo install cross --locked
+            BUILD_CMD="cross"
+          fi
           # Use matrix-level feature override if set, otherwise use global RELEASE_CARGO_FEATURES
           FEATURES="${{ matrix.cargo_features || env.RELEASE_CARGO_FEATURES }}"
           if [ "${{ matrix.skip_prometheus || 'false' }}" = "true" ]; then
-            cargo build --release --locked --no-default-features --features "${FEATURES},channel-nostr,skill-creation" --target ${{ matrix.target }}
+            $BUILD_CMD build --release --locked --no-default-features --features "${FEATURES},channel-nostr,skill-creation" --target ${{ matrix.target }}
           else
-            cargo build --release --locked --features "${FEATURES}" --target ${{ matrix.target }}
+            $BUILD_CMD build --release --locked --features "${FEATURES}" --target ${{ matrix.target }}
           fi
 
       - name: Check binary size
@@ -377,6 +388,7 @@ jobs:
           required_assets=(
             "hrafn-x86_64-unknown-linux-gnu.tar.gz"
             "hrafn-aarch64-unknown-linux-gnu.tar.gz"
+            "hrafn-aarch64-unknown-linux-musl.tar.gz"
             "hrafn-armv7-unknown-linux-gnueabihf.tar.gz"
             "hrafn-arm-unknown-linux-gnueabihf.tar.gz"
             "hrafn-aarch64-apple-darwin.tar.gz"


### PR DESCRIPTION
## Summary
- Add `aarch64-unknown-linux-musl` build target to beta and stable release workflows
- Uses `cross` for musl cross-compilation (new `use_cross` matrix flag)
- Excludes `channel-matrix` for musl (matrix-sdk hits recursion limit under musl)
- Adds musl tarball to required release assets verification

## Context
Alpine Linux on Raspberry Pi Zero 2 W uses musl libc. The existing `aarch64-unknown-linux-gnu` binary requires glibc and cannot run on Alpine even with `gcompat`. This enables auto-updates on the Pi from GitHub releases.

## Test plan
- [ ] Beta release workflow produces `hrafn-aarch64-unknown-linux-musl.tar.gz`
- [ ] Binary runs on Alpine Linux aarch64 (`/tmp/hrafn --version`)
- [ ] SHA256SUMS includes the musl artifact
- [ ] Existing targets are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ARM64 Linux with musl standard library binaries in official releases, enabling deployment on additional hardware architectures and compatible Linux systems.

* **Chores**
  * Enhanced release workflows with support for cross-platform compilation, improving build flexibility and platform coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->