### PR TITLE
chore: fix .coderabbit.yaml schema for v2 compatibility

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,32 +8,26 @@ early_access: false
 reviews:
   # Request changes workflow
   request_changes_workflow: false
-  
+
   # High level summary of the PR
   high_level_summary: true
-  
+
   # Generate sequence diagrams
   sequence_diagrams: true
-  
+
   # Auto-review configuration
   auto_review:
     enabled: true
-    # Only review PRs targeting these branches
-    base_branches:
-      - master
     # Skip reviews for draft PRs or WIP
     drafts: false
-  
+
   # Poem feature toggle (must be a boolean, not an object)
   poem: false
-  
+
   # Reviewer suggestions
-  reviewer:
-    # Suggest reviewers based on blame data
-    enabled: true
-    # Automatically assign suggested reviewers
-    auto_assign: false
-  
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+
   # Enable finishing touches
   finishing_touches:
     # Generate docstrings
@@ -43,29 +37,34 @@ reviews:
     unit_tests:
       enabled: true
 
-# Tools configuration
-tools:
-  # Rust-specific tools
-  cargo:
-    enabled: true
-  
+  # Tools configuration
+  tools:
+    clippy:
+      enabled: true
+
+  # Path filters - ignore generated files
+  path_filters:
+    - "!**/target/**"
+    - "!**/node_modules/**"
+    - "!**/.cargo/**"
+    - "!**/Cargo.lock"
+
+  # Review instructions specific to Rust and this project
+  path_instructions:
+    - path: "**/*.rs"
+      instructions: |
+        Focus on Rust best practices and idiomatic code.
+        Ensure proper error handling with Result types.
+        Verify memory safety and avoid unnecessary clones.
+        Check for proper use of lifetimes and borrowing.
+    - path: "src/security/**"
+      instructions: |
+        Check for security vulnerabilities in encryption/crypto code.
+        Ensure tests cover critical security paths.
+    - path: "src/config/**"
+      instructions: |
+        Review configuration migration code carefully.
+
 # Chat configuration
 chat:
   auto_reply: true
-
-# Path filters - ignore generated files
-path_filters:
-  - "!**/target/**"
-  - "!**/node_modules/**"
-  - "!**/.cargo/**"
-  - "!**/Cargo.lock"
-
-# Review instructions specific to Rust and this project
-review_instructions:
-  - "Focus on Rust best practices and idiomatic code"
-  - "Check for security vulnerabilities in encryption/crypto code"
-  - "Ensure proper error handling with Result types"
-  - "Verify memory safety and avoid unnecessary clones"
-  - "Check for proper use of lifetimes and borrowing"
-  - "Ensure tests cover critical security paths"
-  - "Review configuration migration code carefully"


### PR DESCRIPTION
## Summary

- Move `tools`, `path_filters`, `review_instructions` under `reviews` where the v2 schema expects them
- Replace deprecated `reviewer` object with `suggested_reviewers` / `auto_assign_reviewers` booleans
- Rename `cargo` tool to `clippy` (the actual Rust analyzer in CodeRabbit)
- Remove `auto_review.base_branches` (not in v2 schema)
- Convert flat `review_instructions` string list to path-scoped `path_instructions` objects

Fixes the "unrecognized properties" warning that CodeRabbit was reporting on every PR.

## Test plan

- [x] CodeRabbit should stop emitting the "unrecognized key(s)" parsing warning on the next PR review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration structure for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->