### PR TITLE
chore(ci): simplify cross-compilation build command selection

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -247,17 +247,17 @@ jobs:
         if: matrix.ndk
         run: echo "$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
 
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --locked
+
       - name: Build release
         shell: bash
         run: |
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
           fi
-          BUILD_CMD="cargo"
-          if [ "${{ matrix.use_cross || 'false' }}" = "true" ]; then
-            cargo install cross --locked
-            BUILD_CMD="cross"
-          fi
+          BUILD_CMD="${{ matrix.use_cross && 'cross' || 'cargo' }}"
           $BUILD_CMD build --release --locked --features "${{ matrix.features || env.RELEASE_CARGO_FEATURES }}" --target ${{ matrix.target }}
 
       - name: Check binary size

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -260,6 +260,10 @@ jobs:
         if: matrix.ndk
         run: echo "$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
 
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --locked
+
       - name: Build release
         shell: bash
         run: |
@@ -275,7 +279,6 @@ jobs:
           fi
           BUILD_CMD="cargo"
           if [ "${{ matrix.use_cross || 'false' }}" = "true" ]; then
-            cargo install cross --locked
             BUILD_CMD="cross"
           fi
           # Use matrix-level feature override if set, otherwise use global RELEASE_CARGO_FEATURES


### PR DESCRIPTION
## Summary
- Simplify BUILD_CMD selection in release workflows
- Beta: use GitHub expression ternary instead of shell if/else
- Stable: remove redundant `cargo install cross --locked` from inline build logic

## Test plan
- [x] YAML syntax valid
- [x] GitHub expression syntax verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)