### PR TITLE
fix(agent): prevent multi-tool group splitting at protection boundaries

### DIFF
--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -90,16 +90,23 @@ pub(crate) fn emergency_history_trim(
         if history[i].role == "system" {
             i += 1;
         } else if history[i].role == "assistant" {
-            // Count following tool messages — drop as atomic group
+            // Count the full following tool run (not just up to the cutoff)
+            // to avoid splitting a group at the keep_recent boundary.
             let mut tool_count = 0;
-            while i + 1 + tool_count < history.len().saturating_sub(keep_recent)
-                && history[i + 1 + tool_count].role == "tool"
-            {
+            while i + 1 + tool_count < history.len() && history[i + 1 + tool_count].role == "tool" {
                 tool_count += 1;
             }
-            for _ in 0..=tool_count {
-                history.remove(i);
-                dropped += 1;
+            let cutoff = history.len().saturating_sub(keep_recent);
+            // Only drop if the entire group (assistant + all tools) lies
+            // strictly before the protected suffix.
+            if i + 1 + tool_count <= cutoff {
+                for _ in 0..=tool_count {
+                    history.remove(i);
+                    dropped += 1;
+                }
+            } else {
+                // Group crosses into protected region — skip it entirely
+                i += 1 + tool_count;
             }
         } else {
             history.remove(i);

--- a/src/agent/history_pruner.rs
+++ b/src/agent/history_pruner.rs
@@ -111,15 +111,18 @@ pub fn prune_history(messages: &mut Vec<ChatMessage>, config: &HistoryPrunerConf
         while i < messages.len() {
             let protected = protected_indices(messages, config.keep_recent);
             if messages[i].role == "assistant" && !protected[i] {
-                // Count consecutive tool messages following this assistant
+                // Count the full consecutive tool run first, then check
+                // whether every message in the group is unprotected.
+                // Collapsing only an unprotected prefix would orphan
+                // protected tool messages that follow.
                 let mut tool_count = 0;
                 while i + 1 + tool_count < messages.len()
                     && messages[i + 1 + tool_count].role == "tool"
-                    && !protected[i + 1 + tool_count]
                 {
                     tool_count += 1;
                 }
-                if tool_count > 0 {
+                let all_unprotected = (0..tool_count).all(|k| !protected[i + 1 + k]);
+                if tool_count > 0 && all_unprotected {
                     let summary =
                         format!("[Tool exchange: {tool_count} tool call(s) — results collapsed]");
                     messages[i] = ChatMessage {
@@ -151,7 +154,9 @@ pub fn prune_history(messages: &mut Vec<ChatMessage>, config: &HistoryPrunerConf
                 continue;
             }
             if messages[i].role == "assistant" {
-                // Count following tool messages — drop as atomic group
+                // Count full following tool run, then verify the entire
+                // group (assistant + all tools) is unprotected before
+                // dropping. Dropping only part would orphan tool messages.
                 let mut tool_count = 0;
                 while i + 1 + tool_count < messages.len()
                     && messages[i + 1 + tool_count].role == "tool"
@@ -159,12 +164,18 @@ pub fn prune_history(messages: &mut Vec<ChatMessage>, config: &HistoryPrunerConf
                     tool_count += 1;
                 }
                 if tool_count > 0 {
-                    for _ in 0..=tool_count {
-                        messages.remove(i);
+                    let group_all_unprotected = (0..tool_count).all(|k| !protected[i + 1 + k]);
+                    if group_all_unprotected {
+                        for _ in 0..=tool_count {
+                            messages.remove(i);
+                        }
+                        dropped_messages += 1 + tool_count;
+                        dropped_any = true;
+                        break;
                     }
-                    dropped_messages += 1 + tool_count;
-                    dropped_any = true;
-                    break;
+                    // Group crosses protection boundary — skip it
+                    i += 1 + tool_count;
+                    continue;
                 }
             }
             // Non-tool-group message — safe to drop individually
@@ -367,8 +378,9 @@ mod tests {
         for (i, m) in messages.iter().enumerate() {
             if m.role == "tool" {
                 assert!(
-                    i > 0 && messages[i - 1].role == "assistant",
-                    "tool message at index {i} has no preceding assistant"
+                    i > 0
+                        && (messages[i - 1].role == "assistant" || messages[i - 1].role == "tool"),
+                    "tool message at index {i} has no preceding assistant or tool"
                 );
             }
         }
@@ -397,11 +409,12 @@ mod tests {
             collapse_tool_results: true,
         };
         prune_history(&mut messages, &config);
-        // Verify invariant: no tool message without a preceding assistant
+        // Verify invariant: no tool message without a preceding assistant or tool
         for (i, m) in messages.iter().enumerate() {
             if m.role == "tool" {
                 assert!(
-                    i > 0 && messages[i - 1].role == "assistant",
+                    i > 0
+                        && (messages[i - 1].role == "assistant" || messages[i - 1].role == "tool"),
                     "orphaned tool message at index {i}: {:?}",
                     messages.iter().map(|m| &m.role).collect::<Vec<_>>()
                 );
@@ -468,7 +481,8 @@ mod tests {
         for (i, m) in messages.iter().enumerate() {
             if m.role == "tool" {
                 assert!(
-                    i > 0 && messages[i - 1].role == "assistant",
+                    i > 0
+                        && (messages[i - 1].role == "assistant" || messages[i - 1].role == "tool"),
                     "orphaned tool at index {i}: roles = {:?}",
                     messages.iter().map(|m| &m.role).collect::<Vec<_>>()
                 );


### PR DESCRIPTION
### **User description**
## Summary

Addresses CodeRabbit review feedback from PR #74 — four issues where multi-tool groups (assistant + N consecutive tool messages) could be split at protection/keep_recent boundaries, orphaning tool messages and causing provider API errors.

- **Phase 1 collapse** (`history_pruner.rs`): scan the full consecutive tool run before checking protection; only collapse when every message in the group is unprotected
- **Phase 2 budget drop** (`history_pruner.rs`): verify all tool messages in the group are unprotected before dropping; skip the entire group if any member is protected
- **Orphan invariant assertions** (`history_pruner.rs` tests): relax the check to allow `tool` preceded by `tool` (valid in multi-tool groups), not just preceded by `assistant`
- **Emergency trim** (`history.rs`): count the full tool run regardless of the keep_recent cutoff; only drop the group if it lies entirely before the protected suffix

## Test plan

- [x] All 11 existing `history_pruner` tests pass (including multi-tool-group and realistic-pressure scenarios)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --lib -p hrafn -- -D warnings` passes with zero warnings
- [ ] CI gate (`checks-on-pr.yml`) should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history management to treat assistant-tool message exchanges as atomic units, ensuring complete groups are consistently retained or removed together during trimming and pruning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Phase 1 collapse checks full tool run protection

- Phase 2 budget drop skips partially protected groups

- Emergency trim handles atomic tool groups correctly

- Test assertions updated for multi-tool sequences


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Start["Assistant Message"] --> Tools["Consecutive Tool Messages"]
  Tools --> Check{"All Unprotected?"}
  Check -->|"Yes"| Action["Collapse or Drop Group"]
  Check -->|"No"| Skip["Skip Entire Group"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>history_pruner.rs</strong><dd><code>Atomic handling for multi-tool pruning phases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/history_pruner.rs

<ul><li>Phase 1 collapse verifies full tool run protection<br> <li> Phase 2 budget drop skips partially protected groups<br> <li> Test assertions allow <code>tool</code> preceded by <code>tool</code></ul>


</details>


  </td>
  <td><a href="https://github.com/5queezer/hrafn/pull/79/files#diff-2c7cbc43198d2f464a1e1c5719a5b3d839871a476552c1f657f3c306c9454e71">+28/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>history.rs</strong><dd><code>Atomic group awareness for emergency trim</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/history.rs

<ul><li><code>emergency_history_trim</code> counts full tool run regardless of cutoff<br> <li> Drops group only if entirely before protected suffix</ul>


</details>


  </td>
  <td><a href="https://github.com/5queezer/hrafn/pull/79/files#diff-96d9839b8dc3a450f17664c02297c24b70fbee9fec6795be375ba715a14f8728">+14/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

