### PR TITLE
fix(ci): use correct OPENROUTER_API_KEY env var for Qodo PR Agent

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: qodo-ai/pr-agent@v0.33
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENROUTER__KEY: ${{ secrets.OPENROUTER_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           config.model: "openrouter/qwen/qwen3-coder:free"
           config.fallback_models: '["openrouter/qwen/qwen3.6-plus-preview:free"]'
           config.custom_model_max_tokens: "4000"


### PR DESCRIPTION
## Summary
- Fix environment variable name from `OPENROUTER__KEY` to `OPENROUTER_API_KEY`
- The double-underscore was PR Agent's internal config separator syntax, but litellm expects `OPENROUTER_API_KEY`
- Ref: qodo-ai/pr-agent@d82f7d3 `litellm_ai_handler.py:131`

## Test plan
- [ ] PR Agent workflow picks up the API key and runs reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR review workflow configuration for improved secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->