### PR TITLE
chore: add .pr_agent.toml for self-hosted Qodo PR-Agent

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,38 @@
+[config]
+model = "openrouter/qwen/qwen3-coder:free"
+fallback_models = ["openrouter/qwen/qwen3.6-plus-preview:free"]
+custom_model_max_tokens = 4000
+
+[pr_reviewer]
+extra_instructions = """\
+This is a Rust autonomous agent runtime (edition 2024, MSRV 1.87). \
+Review with these priorities:\n\
+1. Security — flag any weakening of access control, policy, or secret handling (src/security/**, src/gateway/**, src/tools/**)\n\
+2. Correctness — proper error handling with Result, no unwrap() in non-test code, memory safety\n\
+3. Rust idioms — borrowing over cloning, proper lifetime usage, idiomatic pattern matching\n\
+4. Scope — reject unrelated changes, speculative abstractions, or feature flags without concrete use\n\
+Skip style nits already caught by rustfmt and clippy.\
+"""
+enable_review_labels_effort = true
+require_tests_review = true
+require_security_review = true
+require_can_be_split_review = true
+num_code_suggestions = 4
+persistent_comment = true
+
+[pr_description]
+extra_instructions = "Use conventional commit style. Mention affected modules (e.g. security, config, channels)."
+publish_labels = true
+publish_description_as_comment = false
+
+[pr_code_suggestions]
+extra_instructions = "Prefer idiomatic Rust: use ? operator, avoid unnecessary allocations, prefer &str over String where possible."
+num_code_suggestions = 3
+
+[github_app]
+override_deployment_type = true
+pr_commands = [
+    "/review",
+    "/describe",
+    "/improve",
+]


### PR DESCRIPTION
### **User description**
## Summary
- Add `.pr_agent.toml` with review instructions tailored to the Rust codebase
- Security-first review focus, Rust idiom checks, scope enforcement
- Skips style nits covered by rustfmt/clippy

## Test plan
- [ ] Trigger `/review` on this PR to verify config is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add AI review configuration for Rust codebase

- Enforce security-first and correctness checks

- Configure model settings and review commands

- Skip style nits handled by linters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config[".pr_agent.toml"] -- "configures" --> Agent["Qodo PR-Agent"]
  Agent -- "applies" --> Rules["Security & Rust Checks"]
  Rules -- "outputs" --> Review["Automated PR Feedback"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Add AI review configuration for Rust codebase</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<ul><li>Defines AI model and fallback parameters<br> <li> Sets security-first review priorities for Rust<br> <li> Enforces conventional commit and module tracking<br> <li> Configures GitHub app commands and review labels</ul>


</details>


  </td>
  <td><a href="https://github.com/5queezer/hrafn/pull/82/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

