### PR TITLE
fix(docs): correct A2A config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,13 @@ Native Agent-to-Agent communication per the open [A2A standard](https://github.c
 ```toml
 [a2a]
 enabled = true
-bind = "127.0.0.1:18800"    # localhost-only by default
 bearer_token = "your-secret"
+# agent_name = "my-agent"        # defaults to config agent name
+# public_url = "https://my-agent.example.com"  # auto-derived from gateway if omitted
+# capabilities = ["research", "coding"]
 ```
 
-Inbound tasks route through the existing agent pipeline. The agent card is auto-generated from your configuration.
+Inbound tasks route through the gateway server and the existing agent pipeline (A2A uses the same gateway port; no separate bind). The agent card is auto-generated from your configuration.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Remove nonexistent `bind` field from A2A config example
- Add actual fields (`agent_name`, `public_url`, `capabilities`) as commented examples
- Clarify A2A server shares the gateway port

Closes #103
Part of #101, #90

## Test plan
- [ ] Verify config fields match `A2aConfig` struct in `src/config/schema.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated A2A configuration docs: removed localhost-only default bind and added optional settings for agent name, public URL (auto-derived when omitted), and capabilities.
  * Clarified that inbound A2A tasks use the gateway port and are routed through the gateway server into the agent pipeline; note that agent cards remain auto-generated from configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->