### PR TITLE
fix(build): pass HRAFN_VERSION through cross Docker container

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = ["HRAFN_VERSION"]


### PR DESCRIPTION
### **User description**
## Summary
- Add `Cross.toml` with `[build.env] passthrough = ["HRAFN_VERSION"]`
- Fixes musl release builds reporting a git commit hash instead of the release tag (e.g. `hrafn ef2fa3e` instead of `hrafn 0.1.0-beta.67`)

## Root cause
`cross` runs builds in a Docker container and doesn't forward arbitrary env vars from the host. The CI workflow sets `HRAFN_VERSION` at the step level, but `cross` doesn't pass it into the container, so `build.rs` falls back to `git describe --tags --always` which outputs only the commit hash (no tags in the shallow checkout).

## Test plan
- [x] Valid TOML syntax
- [ ] Next musl beta release should report correct version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Pass `HRAFN_VERSION` to cross Docker container

- Fix musl release build version reporting

- Add `Cross.toml` for build configuration


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cross.toml</strong><dd><code>Configure cross container environment variable passthrough</code></dd></summary>
<hr>

Cross.toml

<ul><li>Add <code>[build.env]</code> configuration section<br> <li> Enable <code>HRAFN_VERSION</code> environment variable passthrough</ul>


</details>


  </td>
  <td><a href="https://github.com/5queezer/hrafn/pull/120/files#diff-3abca7e5bab5b140e44643dade038033b8a6f6e50771f76c7d48e7bd0b338815">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

