### PR TITLE
fix(ci): skip upstream website redeploy on forks

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -425,6 +425,7 @@ jobs:
   redeploy-website:
     name: Trigger Website Redeploy
     needs: [publish]
+    if: github.repository == '5queezer/hrafn'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger website redeploy

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -519,6 +519,7 @@ jobs:
   redeploy-website:
     name: Trigger Website Redeploy
     needs: [publish]
+    if: github.repository == '5queezer/hrafn'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger website redeploy


### PR DESCRIPTION
## What

Skip the website redeploy job when release workflows run from forks.

The redeploy step dispatches to the canonical 5queezer/hrafn-website repository with an upstream-scoped secret and hardcoded upstream install script URL. Forks cannot perform that upstream-only side effect reliably, so their release runs currently fail with 401 even when the actual build/publish work succeeds.

## How to test

```bash
git diff --check -- .github/workflows/release-beta-on-push.yml .github/workflows/release-stable-manual.yml
rg -n "if: github.repository == '5queezer/hrafn'" .github/workflows/release-beta-on-push.yml .github/workflows/release-stable-manual.yml
```

## Security

- [ ] New network calls or endpoints
- [ ] Secrets/tokens handling changed
- [ ] File system access scope changed
- [ ] SSRF / input validation implications

**Risk and mitigation:** Low risk. The change only prevents forks from calling the upstream website repository. Upstream release automation for 5queezer/hrafn remains unchanged.

## Checklist

- [ ] cargo fmt && cargo clippy -D warnings passes
- [ ] Tests pass, new code has tests
- [x] I can explain every line in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment reliability and security by restricting automated deployment workflows to the official repository only. This prevents accidental or unintended releases from occurring in forked or alternative repository instances, ensuring greater stability and control over production releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->