### PR TITLE
fix(gateway): fix A2A task cancel route that panics on startup

### DIFF
--- a/src/gateway/a2a.rs
+++ b/src/gateway/a2a.rs
@@ -1368,11 +1368,16 @@ pub async fn handle_tasks_get_rest(
 }
 
 /// `POST /tasks/{id}:cancel` — v1.0 REST binding for CancelTask.
+/// The route captures the full `{id}:cancel` segment; the `:cancel` suffix
+/// is stripped at runtime because axum does not support `{param}:suffix` patterns.
 pub async fn handle_tasks_cancel_rest(
     State(state): State<AppState>,
     headers: HeaderMap,
-    axum::extract::Path(task_id): axum::extract::Path<String>,
+    axum::extract::Path(raw): axum::extract::Path<String>,
 ) -> impl IntoResponse {
+    // A2A spec uses gRPC-style `/tasks/{id}:cancel` but axum captures
+    // the full segment including the `:cancel` suffix.
+    let task_id = raw.strip_suffix(":cancel").unwrap_or(&raw).to_string();
     let (Some(_card), Some(task_store)) = (&state.a2a_agent_card, &state.a2a_task_store) else {
         return (
             StatusCode::NOT_FOUND,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -970,8 +970,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
                 .route("/message:send", post(a2a::handle_message_send_rest))
                 .route("/message:stream", post(a2a::handle_message_stream_rest))
                 .route("/tasks", get(a2a::handle_tasks_list_rest))
-                .route("/tasks/{id}", get(a2a::handle_tasks_get_rest))
-                .route("/tasks/{id}:cancel", post(a2a::handle_tasks_cancel_rest))
+                .route("/tasks/{id}", get(a2a::handle_tasks_get_rest).post(a2a::handle_tasks_cancel_rest))
                 .route(
                     "/tasks/by-context/{context_id}",
                     get(a2a::handle_tasks_by_context_rest),


### PR DESCRIPTION
## Summary

- Fix panic on daemon startup when A2A gateway is enabled: `Invalid route "/tasks/{id}:cancel": Only one parameter is allowed per path segment`
- Axum doesn't support `{param}:suffix` patterns in a single path segment. Capture the full segment as `{id_cancel}` and strip the `:cancel` suffix at runtime.
- A2A spec compliance preserved — clients still POST to `/tasks/{id}:cancel`.

**Discovered on:** Alpine Pi (aarch64) during PR #121 testing — the daemon crashed immediately on startup.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -- a2a` — all relevant tests pass
- [ ] Manual: start daemon with A2A enabled, verify no panic
- [ ] Manual: `POST /tasks/{id}:cancel` returns expected response

Closes https://github.com/zeroclaw-labs/zeroclaw/issues/3566

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task cancellation endpoint now uses POST on /tasks/{id} (method-based) instead of a separate :cancel URL.
  * Requests including a trailing ":cancel" suffix are accepted and normalized to the task ID.
  * Improved handling so cancellation requests correctly identify and process task IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->