### PR TITLE
refactor(channels): rename ACP to stdio-rpc

### DIFF
--- a/docs/reference/cli/commands-reference.md
+++ b/docs/reference/cli/commands-reference.md
@@ -11,7 +11,7 @@ Last verified: **March 26, 2026**.
 | `onboard` | Initialize workspace/config quickly or interactively |
 | `agent` | Run interactive chat or single-message mode |
 | `gateway` | Start webhook and WhatsApp HTTP gateway |
-| `acp` | Start ACP (Agent Control Protocol) server over stdio |
+| `stdio-rpc` | Start JSON-RPC session server over stdio |
 | `daemon` | Start supervised runtime (gateway + channels + optional heartbeat/scheduler) |
 | `service` | Manage user-level OS service lifecycle |
 | `doctor` | Run diagnostics and freshness checks |
@@ -61,13 +61,13 @@ Tip:
 
 - In interactive chat, you can ask for route changes in natural language (for example “conversation uses kimi, coding uses gpt-5.3-codex”); the assistant can persist this via tool `model_routing_config`.
 
-### `acp`
+### `stdio-rpc`
 
-- `hrafn acp`
-- `hrafn acp --max-sessions <N>`
-- `hrafn acp --session-timeout <SECONDS>`
+- `hrafn stdio-rpc`
+- `hrafn stdio-rpc --max-sessions <N>`
+- `hrafn stdio-rpc --session-timeout <SECONDS>`
 
-Start the ACP (Agent Control Protocol) server for IDE and tool integration.
+Start the JSON-RPC session server for IDE and tool integration.
 
 - Uses JSON-RPC 2.0 over stdin/stdout
 - Supports methods: `initialize`, `session/new`, `session/prompt`, `session/stop`

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -14,7 +14,6 @@
 //! To add a new channel, implement [`Channel`] in a new submodule and wire it into
 //! [`start_channels`]. See `AGENTS.md` §7.2 for the full change playbook.
 
-pub mod stdio_rpc;
 pub mod bluesky;
 pub mod clawdtalk;
 pub mod cli;
@@ -51,6 +50,7 @@ pub mod session_store;
 pub mod signal;
 pub mod slack;
 pub mod stall_watchdog;
+pub mod stdio_rpc;
 #[cfg(feature = "channel-telegram")]
 pub mod telegram;
 pub mod traits;

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -14,7 +14,7 @@
 //! To add a new channel, implement [`Channel`] in a new submodule and wire it into
 //! [`start_channels`]. See `AGENTS.md` §7.2 for the full change playbook.
 
-pub mod acp_server;
+pub mod stdio_rpc;
 pub mod bluesky;
 pub mod clawdtalk;
 pub mod cli;

--- a/src/channels/stdio_rpc.rs
+++ b/src/channels/stdio_rpc.rs
@@ -223,7 +223,7 @@ impl StdioRpcServer {
         Ok(serde_json::json!({
             "protocolVersion": "1.0",
             "serverInfo": {
-                "name": "hrafn-stdio-rpc",
+                "name": "hrafn-acp",
                 "version": env!("HRAFN_VERSION"),
             },
             "capabilities": {

--- a/src/channels/stdio_rpc.rs
+++ b/src/channels/stdio_rpc.rs
@@ -1,4 +1,4 @@
-//! ACP (Agent Control Protocol) Server — JSON-RPC 2.0 over stdio.
+//! Stdio-RPC Server — JSON-RPC 2.0 session server over stdio.
 //!
 //! Provides an IDE-friendly interface for spawning and managing isolated agent
 //! sessions. Each session wraps an [`Agent`] built from the global config with
@@ -30,17 +30,17 @@ use uuid::Uuid;
 
 // ── Configuration ────────────────────────────────────────────────
 
-/// ACP server configuration (optional `[acp]` section in config.toml).
+/// Stdio-RPC server configuration (optional `[stdio_rpc]` section in config.toml).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
-pub struct AcpServerConfig {
+pub struct StdioRpcConfig {
     /// Maximum number of concurrent sessions. Default: 10.
     pub max_sessions: usize,
     /// Session inactivity timeout in seconds. Default: 3600 (1 hour).
     pub session_timeout_secs: u64,
 }
 
-impl Default for AcpServerConfig {
+impl Default for StdioRpcConfig {
     fn default() -> Self {
         Self {
             max_sessions: 10,
@@ -105,29 +105,29 @@ struct Session {
     workspace_dir: String,
 }
 
-// ── ACP Server ───────────────────────────────────────────────────
+// ── Stdio-RPC Server ─────────────────────────────────────────────
 
-pub struct AcpServer {
+pub struct StdioRpcServer {
     config: Config,
-    acp_config: AcpServerConfig,
+    rpc_config: StdioRpcConfig,
     sessions: Arc<Mutex<HashMap<String, Session>>>,
 }
 
-impl AcpServer {
-    pub fn new(config: Config, acp_config: AcpServerConfig) -> Self {
+impl StdioRpcServer {
+    pub fn new(config: Config, rpc_config: StdioRpcConfig) -> Self {
         Self {
             config,
-            acp_config,
+            rpc_config,
             sessions: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    /// Run the ACP server, reading JSON-RPC requests from stdin and writing
+    /// Run the stdio-RPC server, reading JSON-RPC requests from stdin and writing
     /// responses/notifications to stdout.
     pub async fn run(&self) -> Result<()> {
         info!(
-            "ACP server starting (max_sessions={}, timeout={}s)",
-            self.acp_config.max_sessions, self.acp_config.session_timeout_secs
+            "Stdio-RPC server starting (max_sessions={}, timeout={}s)",
+            self.rpc_config.max_sessions, self.rpc_config.session_timeout_secs
         );
 
         let stdin = tokio::io::stdin();
@@ -136,7 +136,7 @@ impl AcpServer {
 
         // Spawn session reaper
         let sessions = Arc::clone(&self.sessions);
-        let timeout = Duration::from_secs(self.acp_config.session_timeout_secs);
+        let timeout = Duration::from_secs(self.rpc_config.session_timeout_secs);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(60));
             loop {
@@ -161,7 +161,7 @@ impl AcpServer {
             line.clear();
             let bytes_read = reader.read_line(&mut line).await?;
             if bytes_read == 0 {
-                info!("ACP server: stdin closed, shutting down");
+                info!("Stdio-RPC server: stdin closed, shutting down");
                 break;
             }
 
@@ -223,13 +223,13 @@ impl AcpServer {
         Ok(serde_json::json!({
             "protocolVersion": "1.0",
             "serverInfo": {
-                "name": "hrafn-acp",
+                "name": "hrafn-stdio-rpc",
                 "version": env!("HRAFN_VERSION"),
             },
             "capabilities": {
                 "streaming": true,
-                "maxSessions": self.acp_config.max_sessions,
-                "sessionTimeoutSecs": self.acp_config.session_timeout_secs,
+                "maxSessions": self.rpc_config.max_sessions,
+                "sessionTimeoutSecs": self.rpc_config.session_timeout_secs,
             },
             "methods": [
                 "initialize",
@@ -243,12 +243,12 @@ impl AcpServer {
     async fn handle_session_new(&self, params: &Value) -> RpcResult {
         let mut sessions = self.sessions.lock().await;
 
-        if sessions.len() >= self.acp_config.max_sessions {
+        if sessions.len() >= self.rpc_config.max_sessions {
             return Err(RpcError {
                 code: SESSION_LIMIT_REACHED,
                 message: format!(
                     "Maximum session limit reached ({})",
-                    self.acp_config.max_sessions
+                    self.rpc_config.max_sessions
                 ),
                 data: None,
             });
@@ -505,24 +505,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn acp_server_config_defaults() {
-        let cfg = AcpServerConfig::default();
+    fn stdio_rpc_config_defaults() {
+        let cfg = StdioRpcConfig::default();
         assert_eq!(cfg.max_sessions, 10);
         assert_eq!(cfg.session_timeout_secs, 3600);
     }
 
     #[test]
-    fn acp_server_config_deserialize() {
+    fn stdio_rpc_config_deserialize() {
         let json = r#"{"max_sessions": 5, "session_timeout_secs": 1800}"#;
-        let cfg: AcpServerConfig = serde_json::from_str(json).unwrap();
+        let cfg: StdioRpcConfig = serde_json::from_str(json).unwrap();
         assert_eq!(cfg.max_sessions, 5);
         assert_eq!(cfg.session_timeout_secs, 1800);
     }
 
     #[test]
-    fn acp_server_config_deserialize_partial() {
+    fn stdio_rpc_config_deserialize_partial() {
         let json = r#"{"max_sessions": 3}"#;
-        let cfg: AcpServerConfig = serde_json::from_str(json).unwrap();
+        let cfg: StdioRpcConfig = serde_json::from_str(json).unwrap();
         assert_eq!(cfg.max_sessions, 3);
         assert_eq!(cfg.session_timeout_secs, 3600);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ Examples:
     },
 
     /// Start JSON-RPC session server over stdio
-    #[command(name = "stdio-rpc", long_about = "\
+    #[command(name = "stdio-rpc", alias = "acp", long_about = "\
 Start the JSON-RPC session server over stdio.
 
 Launches a JSON-RPC 2.0 server on stdin/stdout for IDE and tool \
@@ -267,7 +267,9 @@ Methods: initialize, session/new, session/prompt, session/stop.
 
 Examples:
   hrafn stdio-rpc                        # start JSON-RPC session server
-  hrafn stdio-rpc --max-sessions 5       # limit concurrent sessions")]
+  hrafn stdio-rpc --max-sessions 5       # limit concurrent sessions
+
+Note: 'acp' is a deprecated alias for this command.")]
     StdioRpc {
         /// Maximum concurrent sessions (default: 10)
         #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,10 @@ Examples:
     },
 
     /// Start JSON-RPC session server over stdio
-    #[command(name = "stdio-rpc", alias = "acp", long_about = "\
+    #[command(
+        name = "stdio-rpc",
+        alias = "acp",
+        long_about = "\
 Start the JSON-RPC session server over stdio.
 
 Launches a JSON-RPC 2.0 server on stdin/stdout for IDE and tool \
@@ -269,7 +272,8 @@ Examples:
   hrafn stdio-rpc                        # start JSON-RPC session server
   hrafn stdio-rpc --max-sessions 5       # limit concurrent sessions
 
-Note: 'acp' is a deprecated alias for this command.")]
+Note: 'acp' is a deprecated alias for this command."
+    )]
     StdioRpc {
         /// Maximum concurrent sessions (default: 10)
         #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,9 +255,9 @@ Examples:
         gateway_command: Option<hrafn::GatewayCommands>,
     },
 
-    /// Start ACP (Agent Control Protocol) server over stdio
-    #[command(long_about = "\
-Start the ACP server (JSON-RPC 2.0 over stdio).
+    /// Start JSON-RPC session server over stdio
+    #[command(name = "stdio-rpc", long_about = "\
+Start the JSON-RPC session server over stdio.
 
 Launches a JSON-RPC 2.0 server on stdin/stdout for IDE and tool \
 integration. Supports session management and streaming agent \
@@ -266,9 +266,9 @@ responses as notifications.
 Methods: initialize, session/new, session/prompt, session/stop.
 
 Examples:
-  hrafn acp                        # start ACP server
-  hrafn acp --max-sessions 5       # limit concurrent sessions")]
-    Acp {
+  hrafn stdio-rpc                        # start JSON-RPC session server
+  hrafn stdio-rpc --max-sessions 5       # limit concurrent sessions")]
+    StdioRpc {
         /// Maximum concurrent sessions (default: 10)
         #[arg(long)]
         max_sessions: Option<usize>,
@@ -1059,18 +1059,18 @@ async fn main() -> Result<()> {
             .map(|_| ())
         }
 
-        Commands::Acp {
+        Commands::StdioRpc {
             max_sessions,
             session_timeout,
         } => {
-            let mut acp_config = channels::acp_server::AcpServerConfig::default();
+            let mut rpc_config = channels::stdio_rpc::StdioRpcConfig::default();
             if let Some(max) = max_sessions {
-                acp_config.max_sessions = max;
+                rpc_config.max_sessions = max;
             }
             if let Some(timeout) = session_timeout {
-                acp_config.session_timeout_secs = timeout;
+                rpc_config.session_timeout_secs = timeout;
             }
-            let server = channels::acp_server::AcpServer::new(config, acp_config);
+            let server = channels::stdio_rpc::StdioRpcServer::new(config, rpc_config);
             server.run().await
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2956,4 +2956,23 @@ mod tests {
 
         assert!((final_temperature - 0.7).abs() < f64::EPSILON);
     }
+
+    #[test]
+    fn stdio_rpc_command_parses() {
+        let cli =
+            Cli::try_parse_from(["hrafn", "stdio-rpc"]).expect("stdio-rpc command should parse");
+        match cli.command {
+            Commands::StdioRpc { .. } => {}
+            other => panic!("expected StdioRpc command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn acp_alias_parses_to_stdio_rpc() {
+        let cli = Cli::try_parse_from(["hrafn", "acp"]).expect("acp alias should parse");
+        match cli.command {
+            Commands::StdioRpc { .. } => {}
+            other => panic!("expected StdioRpc command via acp alias, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Renames the misnamed "ACP" (Agent Control Protocol) module to "stdio-rpc"
- The module is a JSON-RPC 2.0 session server over stdio for IDE integration — it has nothing to do with IBM's ACP (Agent Communication Protocol) for structured inter-agent messaging
- Frees the "ACP" name for a potential future real ACP implementation
- Pure rename, no functional changes

### Changes
- `src/channels/acp_server.rs` → `src/channels/stdio_rpc.rs`
- `AcpServer` → `StdioRpcServer`, `AcpServerConfig` → `StdioRpcConfig`
- CLI command: `hrafn acp` → `hrafn stdio-rpc`
- Updated docs in `commands-reference.md`

## Test plan
- [x] `cargo check` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command reference to reflect the rename and revised examples.

* **New Features**
  * CLI subcommand renamed from `acp` to `stdio-rpc` and described as a JSON-RPC session server over stdio.
  * `acp` retained as a deprecated alias for compatibility.
  * Server identification and CLI help text updated to the new command name.

* **Bug Fixes**
  * Existing flags `--max-sessions` and `--session-timeout` continue to work unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->