### PR TITLE
fix(agent): preserve tool_call_id during tool result truncation

### DIFF
--- a/src/agent/context_compressor.rs
+++ b/src/agent/context_compressor.rs
@@ -276,7 +276,7 @@ impl ContextCompressor {
                 continue;
             }
             let original_len = msg.content.len();
-            msg.content = crate::agent::loop_::truncate_tool_result(&msg.content, max);
+            msg.content = crate::agent::history::truncate_tool_message(&msg.content, max);
             saved += original_len - msg.content.len();
         }
         saved

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -55,6 +55,30 @@ pub(crate) fn truncate_tool_result(output: &str, max_chars: usize) -> String {
     )
 }
 
+/// Truncate a tool message's content, preserving JSON structure when the
+/// message stores `tool_call_id` alongside `content` (native tool-call
+/// format). Without this, `truncate_tool_result` destroys the JSON envelope
+/// and downstream providers receive a `null` `call_id`.
+///
+/// Ported from zeroclaw-labs/zeroclaw#5457.
+pub(crate) fn truncate_tool_message(msg_content: &str, max_chars: usize) -> String {
+    if max_chars == 0 || msg_content.len() <= max_chars {
+        return msg_content.to_string();
+    }
+    if let Ok(mut obj) =
+        serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(msg_content)
+    {
+        if obj.contains_key("tool_call_id") {
+            if let Some(serde_json::Value::String(inner)) = obj.get("content") {
+                let truncated = truncate_tool_result(inner, max_chars);
+                obj.insert("content".to_string(), serde_json::Value::String(truncated));
+                return serde_json::to_string(&obj).unwrap_or_else(|_| msg_content.to_string());
+            }
+        }
+    }
+    truncate_tool_result(msg_content, max_chars)
+}
+
 /// Aggressively trim old tool result messages in history to recover from
 /// context overflow. Keeps the last `protect_last_n` messages untouched.
 /// Returns total characters saved.
@@ -68,7 +92,7 @@ pub(crate) fn fast_trim_tool_results(
     for msg in &mut history[..cutoff] {
         if msg.role == "tool" && msg.content.len() > trim_to {
             let original_len = msg.content.len();
-            msg.content = truncate_tool_result(&msg.content, trim_to);
+            msg.content = truncate_tool_message(&msg.content, trim_to);
             saved += original_len - msg.content.len();
         }
     }

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -92,8 +92,11 @@ pub(crate) fn fast_trim_tool_results(
     for msg in &mut history[..cutoff] {
         if msg.role == "tool" && msg.content.len() > trim_to {
             let original_len = msg.content.len();
-            msg.content = truncate_tool_message(&msg.content, trim_to);
-            saved += original_len - msg.content.len();
+            let truncated = truncate_tool_message(&msg.content, trim_to);
+            if truncated.len() < original_len {
+                saved += original_len - truncated.len();
+                msg.content = truncated;
+            }
         }
     }
     saved

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -4936,6 +4936,39 @@ mod tests {
         assert!(result.ends_with("yz"));
     }
 
+    // ── truncate_tool_message tests ─────────────────────────────
+
+    #[test]
+    fn truncate_tool_message_preserves_json_structure() {
+        use crate::agent::history::truncate_tool_message;
+        let big_content = "x".repeat(5000);
+        let msg = serde_json::json!({
+            "tool_call_id": "call_abc123",
+            "content": big_content,
+        })
+        .to_string();
+        let result = truncate_tool_message(&msg, 2000);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["tool_call_id"], "call_abc123");
+        assert!(parsed["content"].as_str().unwrap().contains("[... "));
+    }
+
+    #[test]
+    fn truncate_tool_message_plain_text_fallback() {
+        use crate::agent::history::truncate_tool_message;
+        let plain = "a".repeat(5000);
+        let result = truncate_tool_message(&plain, 2000);
+        assert!(result.contains("[... "));
+        assert!(result.len() < 5000);
+    }
+
+    #[test]
+    fn truncate_tool_message_short_passthrough() {
+        use crate::agent::history::truncate_tool_message;
+        let msg = r#"{"tool_call_id":"call_1","content":"ok"}"#;
+        assert_eq!(truncate_tool_message(msg, 2000), msg);
+    }
+
     // ── fast_trim_tool_results tests ────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

- Introduced `truncate_tool_message()` in `history.rs` that parses JSON tool messages, truncates only the inner `content` field, and preserves the `tool_call_id` envelope.
- Updated both truncation call sites (`history::fast_trim_tool_results` and `context_compressor::fast_trim_tool_results`) to use the new JSON-aware function.
- Without this fix, `truncate_tool_result` destroys the JSON envelope carrying `tool_call_id`, causing downstream OpenAI-compatible providers to receive `null` `call_id` and return `400 Bad Request`.

## Upstream reference

Ported from [zeroclaw-labs/zeroclaw#5457](https://github.com/zeroclaw-labs/zeroclaw/pull/5457) (merged upstream). Original issue: zeroclaw-labs/zeroclaw#5425.

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --lib truncate_tool` — 10 passed (7 existing + 3 new)
- [x] `cargo test --lib fast_trim` — 10 passed (all existing)
- [ ] Verify in CI: `./dev/ci.sh all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced tool message truncation to preserve JSON structure when processing large tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->