### PR TITLE
fix(security): enforce workspace boundary in full-autonomy mode

### DIFF
--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1603,10 +1603,20 @@ impl SecurityPolicy {
             };
         }
 
+        // When autonomy is Full, disable workspace_only so the agent can
+        // access paths outside the workspace.  Forbidden-path checks still
+        // apply, preventing access to sensitive system directories.
+        // Ported from zeroclaw-labs/zeroclaw#5486.
+        let effective_workspace_only = if autonomy_config.level == AutonomyLevel::Full {
+            false
+        } else {
+            autonomy_config.workspace_only
+        };
+
         Self {
             autonomy: autonomy_config.level,
             workspace_dir: workspace_dir.to_path_buf(),
-            workspace_only: autonomy_config.workspace_only,
+            workspace_only: effective_workspace_only,
             allowed_commands: autonomy_config.allowed_commands.clone(),
             forbidden_paths: autonomy_config.forbidden_paths.clone(),
             allowed_roots: autonomy_config
@@ -2240,6 +2250,40 @@ mod tests {
 
         assert_eq!(policy.allowed_roots[0], expected_home_root);
         assert_eq!(policy.allowed_roots[1], workspace.join("shared-data"));
+    }
+
+    #[test]
+    fn from_config_full_autonomy_overrides_workspace_only() {
+        // Full autonomy should disable workspace_only even if the
+        // config default keeps it true.
+        // Ported from zeroclaw-labs/zeroclaw#5486.
+        let autonomy_config = crate::config::AutonomyConfig {
+            level: AutonomyLevel::Full,
+            ..crate::config::AutonomyConfig::default()
+        };
+        let workspace = PathBuf::from("/tmp/test-workspace");
+        let policy = SecurityPolicy::from_config(&autonomy_config, &workspace, true);
+
+        assert_eq!(policy.autonomy, AutonomyLevel::Full);
+        assert!(
+            !policy.workspace_only,
+            "Full autonomy must override workspace_only to false"
+        );
+    }
+
+    #[test]
+    fn from_config_supervised_preserves_workspace_only() {
+        let autonomy_config = crate::config::AutonomyConfig {
+            level: AutonomyLevel::Supervised,
+            ..crate::config::AutonomyConfig::default()
+        };
+        let workspace = PathBuf::from("/tmp/test-workspace");
+        let policy = SecurityPolicy::from_config(&autonomy_config, &workspace, true);
+
+        assert!(
+            policy.workspace_only,
+            "Supervised autonomy must preserve workspace_only default (true)"
+        );
     }
 
     #[test]

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1603,20 +1603,10 @@ impl SecurityPolicy {
             };
         }
 
-        // When autonomy is Full, disable workspace_only so the agent can
-        // access paths outside the workspace.  Forbidden-path checks still
-        // apply, preventing access to sensitive system directories.
-        // Ported from zeroclaw-labs/zeroclaw#5486.
-        let effective_workspace_only = if autonomy_config.level == AutonomyLevel::Full {
-            false
-        } else {
-            autonomy_config.workspace_only
-        };
-
         Self {
             autonomy: autonomy_config.level,
             workspace_dir: workspace_dir.to_path_buf(),
-            workspace_only: effective_workspace_only,
+            workspace_only: autonomy_config.workspace_only,
             allowed_commands: autonomy_config.allowed_commands.clone(),
             forbidden_paths: autonomy_config.forbidden_paths.clone(),
             allowed_roots: autonomy_config
@@ -2253,12 +2243,12 @@ mod tests {
     }
 
     #[test]
-    fn from_config_full_autonomy_overrides_workspace_only() {
-        // Full autonomy should disable workspace_only even if the
-        // config default keeps it true.
+    fn from_config_full_autonomy_preserves_workspace_only() {
+        // Full autonomy should honor explicit workspace_only settings.
         // Ported from zeroclaw-labs/zeroclaw#5486.
         let autonomy_config = crate::config::AutonomyConfig {
             level: AutonomyLevel::Full,
+            workspace_only: true,
             ..crate::config::AutonomyConfig::default()
         };
         let workspace = PathBuf::from("/tmp/test-workspace");
@@ -2266,8 +2256,8 @@ mod tests {
 
         assert_eq!(policy.autonomy, AutonomyLevel::Full);
         assert!(
-            !policy.workspace_only,
-            "Full autonomy must override workspace_only to false"
+            policy.workspace_only,
+            "Full autonomy must preserve workspace_only=true"
         );
     }
 


### PR DESCRIPTION
## Summary

- Ports the security policy fix from zeroclaw-labs/zeroclaw#5486 to Hrafn
- When autonomy is `Full`, `SecurityPolicy::from_config` now overrides `workspace_only` to `false`, allowing the agent to access paths outside the workspace directory
- Forbidden-path enforcement is preserved for all autonomy levels -- sensitive system directories remain blocked regardless of autonomy setting

## Background

`AutonomyConfig` defaults `workspace_only` to `true`. When a user sets `level = "full"`, they expect unrestricted path access (within forbidden-path bounds). Previously, `from_config` passed through the default `workspace_only: true` unchanged, contradicting the documented intent of full autonomy.

## Upstream reference

Ported from [zeroclaw-labs/zeroclaw#5486](https://github.com/zeroclaw-labs/zeroclaw/pull/5486). The upstream PR also wired hooks into the library `Agent::from_config` path -- that change is a separate concern (`src/agent/`, not `src/security/`) and is not included in this PR per one-concern-per-PR discipline.

## Security impact

- File system access scope changed: Yes -- full autonomy now bypasses `workspace_only` restriction
- Mitigation: Forbidden-path enforcement (`/etc`, `/root`, etc.) is preserved regardless of autonomy level. Users can explicitly set `workspace_only = true` in config to restore previous behavior.
- No new permissions, network calls, or secrets handling changes.

## Validation

```bash
cargo check          # passes
cargo fmt --all -- --check  # passes
cargo test --lib security::policy::tests::from_config  # 6 passed (including 2 new tests)
```

## Test plan

- [x] `from_config_full_autonomy_overrides_workspace_only` -- verifies Full autonomy sets workspace_only=false
- [x] `from_config_supervised_preserves_workspace_only` -- verifies Supervised mode preserves workspace_only=true
- [x] All existing `from_config` tests continue to pass
- [ ] Manual: verify forbidden paths still blocked under full autonomy


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering security policy behavior: verifies workspace-only setting is preserved for full autonomy when explicitly enabled, and for supervised autonomy when relying on defaults. This increases test coverage around workspace restriction handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->