### PR TITLE
feat(channel): propagate sender user ID into channel system prompt

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -683,14 +683,19 @@ fn build_channel_system_prompt(
     }
 
     if !reply_target.is_empty() {
+        // Sanitise metadata to prevent control characters from breaking prompt
+        // structure (newlines, carriage returns).
+        let safe_channel = channel_name.replace(['\r', '\n'], " ");
+        let safe_reply = reply_target.replace(['\r', '\n'], " ");
+        let safe_sender = sender.replace(['\r', '\n'], " ");
         let context = format!(
-            "\n\nChannel context: You are currently responding on channel={channel_name}, \
-             reply_target={reply_target}, sender={sender}. \
+            "\n\nChannel context: You are currently responding on channel={safe_channel}, \
+             reply_target={safe_reply}, sender={safe_sender}. \
              The sender field is the platform-specific user ID of the person who sent \
              this message. Use it to distinguish between different users. \
              When scheduling delayed messages or reminders \
              via cron_add for this conversation, use delivery={{\"mode\":\"announce\",\
-             \"channel\":\"{channel_name}\",\"to\":\"{reply_target}\"}} so the message \
+             \"channel\":\"{safe_channel}\",\"to\":\"{safe_reply}\"}} so the message \
              reaches the user."
         );
         prompt.push_str(&context);

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -651,6 +651,7 @@ fn build_channel_system_prompt(
     base_prompt: &str,
     channel_name: &str,
     reply_target: &str,
+    sender: &str,
 ) -> String {
     let mut prompt = base_prompt.to_string();
 
@@ -684,7 +685,10 @@ fn build_channel_system_prompt(
     if !reply_target.is_empty() {
         let context = format!(
             "\n\nChannel context: You are currently responding on channel={channel_name}, \
-             reply_target={reply_target}. When scheduling delayed messages or reminders \
+             reply_target={reply_target}, sender={sender}. \
+             The sender field is the platform-specific user ID of the person who sent \
+             this message. Use it to distinguish between different users. \
+             When scheduling delayed messages or reminders \
              via cron_add for this conversation, use delivery={{\"mode\":\"announce\",\
              \"channel\":\"{channel_name}\",\"to\":\"{reply_target}\"}} so the message \
              reaches the user."
@@ -2688,8 +2692,12 @@ async fn process_channel_message(
     } else {
         refreshed_new_session_system_prompt(ctx.as_ref())
     };
-    let mut system_prompt =
-        build_channel_system_prompt(&base_system_prompt, &msg.channel, &msg.reply_target);
+    let mut system_prompt = build_channel_system_prompt(
+        &base_system_prompt,
+        &msg.channel,
+        &msg.reply_target,
+        &msg.sender,
+    );
     if !memory_context.is_empty() {
         let _ = write!(system_prompt, "\n\n{memory_context}");
     }
@@ -11704,5 +11712,34 @@ This is an example JSON object for profile settings."#;
     fn default_keep_tool_context_turns_is_two() {
         let config = crate::config::schema::AgentConfig::default();
         assert_eq!(config.keep_tool_context_turns, 2);
+    }
+
+    #[test]
+    fn build_channel_system_prompt_includes_sender_id() {
+        let prompt = build_channel_system_prompt(
+            "You are a helpful assistant.",
+            "mattermost",
+            "channel123:root456",
+            "user_abc123",
+        );
+        assert!(prompt.contains("sender=user_abc123"));
+        assert!(prompt.contains("channel=mattermost"));
+        assert!(prompt.contains("reply_target=channel123:root456"));
+    }
+
+    #[test]
+    fn build_channel_system_prompt_omits_context_when_reply_target_empty() {
+        let prompt = build_channel_system_prompt("Base prompt.", "mattermost", "", "user_abc123");
+        assert!(!prompt.contains("sender="));
+        assert!(!prompt.contains("Channel context:"));
+    }
+
+    #[test]
+    fn build_channel_system_prompt_sender_distinguishes_users() {
+        let prompt_a = build_channel_system_prompt("Base.", "mattermost", "ch:thread", "user_aaa");
+        let prompt_b = build_channel_system_prompt("Base.", "mattermost", "ch:thread", "user_bbb");
+        assert!(prompt_a.contains("sender=user_aaa"));
+        assert!(prompt_b.contains("sender=user_bbb"));
+        assert_ne!(prompt_a, prompt_b);
     }
 }


### PR DESCRIPTION
## Summary

- Ports [zeroclaw-labs/zeroclaw#5526](https://github.com/zeroclaw-labs/zeroclaw/pull/5526) to Hrafn
- Adds the sender's platform-specific user ID to the channel system prompt context, enabling the model to distinguish between different users in channel conversations
- Passes `msg.sender` through `build_channel_system_prompt` so the prompt includes `sender=<id>` alongside the existing `channel=` and `reply_target=` fields

## Upstream attribution

Original feature by @titulus in zeroclaw-labs/zeroclaw#5526.

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Three new unit tests verify sender propagation:
  - `build_channel_system_prompt_includes_sender_id` — confirms sender appears in prompt
  - `build_channel_system_prompt_omits_context_when_reply_target_empty` — confirms no channel context when reply_target is empty
  - `build_channel_system_prompt_sender_distinguishes_users` — confirms different senders produce different prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Channel messages now include sender identification in the generated channel context.
  * Channel context and delivery payload values are sanitized to remove newlines/spurious characters.
  * Channel context is omitted when no reply target is present.

* **Tests**
  * Added tests for sender inclusion, omission of channel context when appropriate, and differing prompts for different senders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->