### PR TITLE
fix(agent): drop orphan tool_results when trimming history

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -579,7 +579,23 @@ impl Agent {
         }
 
         if other_messages.len() > max {
-            let drop_count = other_messages.len() - max;
+            let mut drop_count = other_messages.len() - max;
+
+            // Avoid creating orphan ToolResults: if the first message remaining
+            // after the drop is a ToolResults, its paired AssistantToolCalls was
+            // dropped, so the ToolResults must be dropped too. Otherwise the
+            // history would start with a tool_result block whose tool_use_id
+            // has no matching tool_use, causing providers (e.g. Anthropic) to
+            // reject the request with a 400.
+            while drop_count < other_messages.len()
+                && matches!(
+                    &other_messages[drop_count],
+                    ConversationMessage::ToolResults(_)
+                )
+            {
+                drop_count += 1;
+            }
+
             other_messages.drain(0..drop_count);
         }
 
@@ -1887,5 +1903,95 @@ mod tests {
             has_tool_result,
             "Should have emitted a ToolResult event for 'echo'"
         );
+    }
+
+    /// Regression test for the orphan-tool_results trim bug.
+    ///
+    /// `trim_history` previously dropped the oldest N entries blindly. When
+    /// the boundary fell in the middle of an `AssistantToolCalls` /
+    /// `ToolResults` pair, the call side was dropped while the result side
+    /// remained — leaving an orphan `ToolResults` at the head of the
+    /// history. The next provider request then started with a `tool_result`
+    /// block that had no matching `tool_use`, which Anthropic rejects with
+    /// a 400.
+    #[test]
+    fn trim_history_does_not_leave_orphan_tool_results() {
+        use crate::providers::{ToolCall, ToolResultMessage};
+
+        let memory_cfg = crate::config::MemoryConfig {
+            backend: "none".into(),
+            ..crate::config::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            crate::memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let mut agent_config = crate::config::AgentConfig::default();
+        // 5 entries (AC, TR, AC, TR, AC) with max=4 → drop_count=1 → AC1 dropped,
+        // TR1 left as orphan unless the trim guards against it.
+        agent_config.max_history_messages = 4;
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .provider(Box::new(MockProvider {
+                responses: Mutex::new(vec![]),
+            }))
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .config(agent_config)
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        // Clear any auto-generated system message so history is only our entries.
+        agent.history.clear();
+
+        // Build history: AC1, TR1, AC2, TR2, AC3 (5 entries, no trailing TR3).
+        for i in 1..=3 {
+            agent.history.push(ConversationMessage::AssistantToolCalls {
+                text: Some(format!("Calling tool {i}")),
+                tool_calls: vec![ToolCall {
+                    id: format!("tc{i}"),
+                    name: format!("tool{i}"),
+                    arguments: "{}".into(),
+                }],
+                reasoning_content: None,
+            });
+            if i < 3 {
+                agent
+                    .history
+                    .push(ConversationMessage::ToolResults(vec![ToolResultMessage {
+                        tool_call_id: format!("tc{i}"),
+                        content: format!("result{i}"),
+                    }]));
+            }
+        }
+
+        assert_eq!(agent.history.len(), 5);
+        agent.trim_history();
+
+        // The surviving history must not start with a ToolResults entry.
+        if let Some(first) = agent.history.first() {
+            assert!(
+                !matches!(first, ConversationMessage::ToolResults(_)),
+                "trim_history left an orphan ToolResults at the head of the \
+                 history; this would cause Anthropic to reject the next \
+                 request with a 400"
+            );
+        }
+
+        // Every ToolResults must be immediately preceded by an AssistantToolCalls.
+        for window in agent.history.windows(2) {
+            if matches!(&window[1], ConversationMessage::ToolResults(_)) {
+                assert!(
+                    matches!(&window[0], ConversationMessage::AssistantToolCalls { .. }),
+                    "ToolResults entry is not preceded by an AssistantToolCalls \
+                     entry — pair was split during trim"
+                );
+            }
+        }
     }
 }

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -144,7 +144,17 @@ pub(crate) fn trim_history(history: &mut Vec<ChatMessage>, max_history: usize) {
     }
 
     let start = if has_system { 1 } else { 0 };
-    let to_remove = non_system_count - max_history;
+    let mut to_remove = non_system_count - max_history;
+
+    // Avoid creating orphan tool results: if the first message remaining
+    // after the drop has role "tool", its paired assistant message was
+    // dropped, so the tool result must be dropped too. Otherwise the
+    // history would contain a tool_result without a matching tool_use,
+    // causing providers to reject the request with a 400.
+    while start + to_remove < history.len() && history[start + to_remove].role == "tool" {
+        to_remove += 1;
+    }
+
     history.drain(start..start + to_remove);
 }
 

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -8838,6 +8838,46 @@ Let me check the result."#;
         assert_eq!(history[1].content, "new msg");
     }
 
+    /// Regression: trim_history must not leave an orphan tool result whose
+    /// paired assistant message was dropped. Such an orphan causes providers
+    /// to reject the request with a 400 ("unexpected tool_use_id").
+    #[test]
+    fn trim_history_drops_orphan_tool_results() {
+        use crate::providers::ChatMessage;
+
+        // system, assistant, tool, user, assistant — max=2 → drop 2 non-system.
+        // Without the fix: drops assistant+tool → head is user (fine).
+        // Edge case: system, assistant, tool, assistant, tool, user — max=3 → drop 2.
+        // Without fix: drops [assistant, tool] → head is [assistant, tool, user] (fine).
+        // Real repro: system, user, assistant, tool, user — max=2 → drop 2.
+        // Drops [user, assistant] → head is [tool, user] — orphan tool!
+        let mut history = vec![
+            ChatMessage::system("sys"),
+            ChatMessage::user("old q"),
+            ChatMessage::assistant("calling tool"),
+            ChatMessage::tool("tool result"),
+            ChatMessage::user("new q"),
+        ];
+        trim_history(&mut history, 2);
+
+        // System must be preserved.
+        assert_eq!(history[0].role, "system");
+        // No message after system should have role "tool" without a preceding assistant.
+        for window in history.windows(2) {
+            if window[1].role == "tool" {
+                assert_eq!(
+                    window[0].role, "assistant",
+                    "orphan tool result left after trim — tool message without preceding assistant"
+                );
+            }
+        }
+        // Head of non-system messages must not be "tool".
+        assert_ne!(
+            history[1].role, "tool",
+            "trim_history left an orphan tool result at the head"
+        );
+    }
+
     /// When `build_system_prompt_with_mode` is called with `native_tools = true`,
     /// the output must contain ZERO XML protocol artifacts. In the native path
     /// `build_tool_instructions` is never called, so the system prompt alone


### PR DESCRIPTION
## Summary
- Ports zeroclaw-labs/zeroclaw#5485 by @hwc9169
- Orphan tool_results (without preceding tool_call) left after history trimming cause provider API 400 errors
- Adapted for Hrafn's Rust codebase — fixes both `Agent::trim_history` (ConversationMessage enum) and the standalone `trim_history` (ChatMessage role-based)

## Upstream reference
- Original PR: zeroclaw-labs/zeroclaw#5485 by @hwc9169
- Status: Merged upstream
- Changes from original: Adapted from TypeScript to Rust, using Hrafn's message types. Hrafn had two trim_history implementations (one using `ConversationMessage` enum with `ToolResults` variant, one using flat `ChatMessage` with role field) — both were fixed.

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test trim_history` — 11 tests pass (2 new regression tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)