### PR TITLE
fix(channels): strip <think> tags from streaming draft updates

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2028,6 +2028,28 @@ fn extract_tool_context_summary(history: &[ChatMessage], start_index: usize) -> 
     format!("[Used tools: {}]", tool_names.join(", "))
 }
 
+/// Strip `<think>...</think>` blocks from streaming draft text so reasoning
+/// tokens are never shown to the user in partial updates.
+fn strip_think_tags_inline(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut rest = s;
+    loop {
+        if let Some(start) = rest.find("<think>") {
+            result.push_str(&rest[..start]);
+            if let Some(end) = rest[start..].find("</think>") {
+                rest = &rest[start + end + "</think>".len()..];
+            } else {
+                // Unclosed tag: drop the tail to avoid leaking partial reasoning.
+                break;
+            }
+        } else {
+            result.push_str(rest);
+            break;
+        }
+    }
+    result.trim().to_string()
+}
+
 fn sanitize_channel_response(response: &str, tools: &[Box<dyn Tool>]) -> String {
     let known_tool_names: HashSet<String> = tools
         .iter()
@@ -2789,8 +2811,9 @@ async fn process_channel_message(
                             accumulated.clear();
                         }
                         DraftEvent::Progress(text) => {
+                            let visible = strip_think_tags_inline(&text);
                             if let Err(e) = channel
-                                .update_draft_progress(&reply_target, &draft_id, &text)
+                                .update_draft_progress(&reply_target, &draft_id, &visible)
                                 .await
                             {
                                 tracing::debug!("Draft progress update failed: {e}");
@@ -2798,8 +2821,9 @@ async fn process_channel_message(
                         }
                         DraftEvent::Content(text) => {
                             accumulated.push_str(&text);
+                            let visible = strip_think_tags_inline(&accumulated);
                             if let Err(e) = channel
-                                .update_draft(&reply_target, &draft_id, &accumulated)
+                                .update_draft(&reply_target, &draft_id, &visible)
                                 .await
                             {
                                 tracing::debug!("Draft update failed: {e}");
@@ -11624,6 +11648,50 @@ This is an example JSON object for profile settings."#;
         let result = sanitize_channel_response(clean_text, &tools);
 
         assert_eq!(result, clean_text);
+    }
+
+    // ── Tests for strip_think_tags_inline (streaming draft sanitization) ──
+
+    #[test]
+    fn strip_think_tags_inline_removes_single_block() {
+        assert_eq!(
+            strip_think_tags_inline("<think>reasoning</think>Hello"),
+            "Hello"
+        );
+    }
+
+    #[test]
+    fn strip_think_tags_inline_removes_multiple_blocks() {
+        assert_eq!(
+            strip_think_tags_inline("<think>a</think>X<think>b</think>Y"),
+            "XY"
+        );
+    }
+
+    #[test]
+    fn strip_think_tags_inline_handles_unclosed_block() {
+        assert_eq!(
+            strip_think_tags_inline("visible<think>hidden tail"),
+            "visible"
+        );
+    }
+
+    #[test]
+    fn strip_think_tags_inline_preserves_text_without_tags() {
+        assert_eq!(strip_think_tags_inline("plain text"), "plain text");
+    }
+
+    #[test]
+    fn strip_think_tags_inline_handles_empty_string() {
+        assert_eq!(strip_think_tags_inline(""), "");
+    }
+
+    #[test]
+    fn strip_think_tags_inline_strips_surrounding_whitespace() {
+        assert_eq!(
+            strip_think_tags_inline("<think>hidden</think>  Answer  "),
+            "Answer"
+        );
     }
 
     // ── Tests for #4827: tool context preservation ──────────────


### PR DESCRIPTION
## Summary
- Port of upstream fix from zeroclaw-labs/zeroclaw#5505 by @DaBlitzStein
- Models like Qwen emit `<think>...</think>` reasoning blocks that were stripped from the final response but leaked to users during partial streaming
- `DraftEvent::Content` and `DraftEvent::Progress` sent raw accumulated text to `update_draft()` / `update_draft_progress()` without sanitization
- Adds `strip_think_tags_inline()` to `channels/mod.rs` that strips think blocks from streaming draft text before sending to the channel
- Handles single blocks, multiple blocks, unclosed blocks (drops tail), and trims whitespace

## Root cause
The existing `strip_think_tags` functions in `compatible.rs`, `loop_.rs`, `ollama.rs`, and `dispatcher.rs` only operate on the final complete response. The streaming draft handler in `channels/mod.rs` accumulates text chunks and sends them directly to the channel without any think-tag sanitization.

## Test plan
- [x] 6 unit tests for `strip_think_tags_inline`: single block, multiple blocks, unclosed block, no tags, empty string, whitespace trimming
- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] Manual test: Qwen model with `stream_mode = "partial"` no longer shows `<think>` content during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Draft messages now properly exclude internal processing content from display, showing only finalized text to users.

* **Tests**
  * Added comprehensive unit tests for draft message filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->