### PR TITLE
Add integration tests for telegram_user signal pipeline

### DIFF
--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -11,3 +11,4 @@ mod memory_restart;
 mod report_template_tool_test;
 mod telegram_attachment_fallback;
 mod telegram_finalize_draft;
+mod telegram_user_signal;

--- a/tests/integration/telegram_user_signal.rs
+++ b/tests/integration/telegram_user_signal.rs
@@ -90,16 +90,25 @@ fn signal_with_image_attachment() {
 
 #[test]
 fn signal_without_handler_passes_raw_text() {
-    let handler = "";
     let text = "Some channel message";
-    let content = if handler.is_empty() {
-        text.to_string()
-    } else {
-        format!("[handler:{handler}]\n{text}")
-    };
+    let content = build_content("", text);
 
     assert!(!content.starts_with("[handler:"));
     assert_eq!(content, "Some channel message");
+
+    // Also verify that a non-empty handler does produce the prefix.
+    let with_handler = build_content("trading_signal", text);
+    assert!(with_handler.starts_with("[handler:trading_signal]"));
+}
+
+/// Build message content the same way the production listen loop does:
+/// prepend the handler prefix only when the handler string is non-empty.
+fn build_content(handler: &str, text: &str) -> String {
+    if handler.is_empty() {
+        text.to_string()
+    } else {
+        format!("[handler:{handler}]\n{text}")
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -107,24 +116,28 @@ fn signal_without_handler_passes_raw_text() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[cfg(feature = "channel-telegram-user")]
-#[test]
-fn channel_construction_from_config() {
-    use hrafn::channels::telegram_user::TelegramUserChannel;
-    use hrafn::channels::traits::Channel;
+fn test_config(channel: &str, handler: &str) -> hrafn::config::TelegramUserConfig {
     use hrafn::config::{TelegramUserConfig, TelegramUserWatchConfig};
-
-    let config = TelegramUserConfig {
+    TelegramUserConfig {
         api_id: 12345,
         api_hash: "test_hash".to_string(),
         phone: "+1 555 0100".to_string(),
         session_file: "/tmp/test.session".to_string(),
         watch: vec![TelegramUserWatchConfig {
-            channel: "test_channel".to_string(),
-            handler: "trading_signal".to_string(),
+            channel: channel.to_string(),
+            handler: handler.to_string(),
         }],
         reply_via_bot: Some("@test_bot".to_string()),
-    };
+    }
+}
 
+#[cfg(feature = "channel-telegram-user")]
+#[test]
+fn channel_construction_from_config() {
+    use hrafn::channels::telegram_user::TelegramUserChannel;
+    use hrafn::channels::traits::Channel;
+
+    let config = test_config("test_channel", "trading_signal");
     let channel = TelegramUserChannel::new(&config);
     assert_eq!(channel.name(), "telegram_user");
 }
@@ -138,20 +151,8 @@ fn channel_construction_from_config() {
 async fn send_is_noop() {
     use hrafn::channels::telegram_user::TelegramUserChannel;
     use hrafn::channels::traits::{Channel, SendMessage};
-    use hrafn::config::{TelegramUserConfig, TelegramUserWatchConfig};
 
-    let config = TelegramUserConfig {
-        api_id: 12345,
-        api_hash: "test_hash".to_string(),
-        phone: "+1 555 0100".to_string(),
-        session_file: "/tmp/test.session".to_string(),
-        watch: vec![TelegramUserWatchConfig {
-            channel: "test".to_string(),
-            handler: "".to_string(),
-        }],
-        reply_via_bot: Some("@test_bot".to_string()),
-    };
-
+    let config = test_config("test", "");
     let channel = TelegramUserChannel::new(&config);
     let msg = SendMessage::new("hello", "@someone");
 
@@ -166,7 +167,7 @@ async fn send_is_noop() {
 
 #[test]
 fn multiple_watch_configs_produce_distinct_messages() {
-    let channels = vec![("channel_a", "handler_1"), ("channel_b", "handler_2")];
+    let channels = [("channel_a", "handler_1"), ("channel_b", "handler_2")];
 
     let messages: Vec<ChannelMessage> = channels
         .iter()

--- a/tests/integration/telegram_user_signal.rs
+++ b/tests/integration/telegram_user_signal.rs
@@ -1,0 +1,196 @@
+//! Integration tests for the telegram_user channel signal pipeline.
+//!
+//! Since we can't connect to real Telegram (needs credentials), these tests
+//! verify the testable contracts: message construction, handler prefix logic,
+//! ID uniqueness, attachment structure, and Channel trait behaviour.
+//!
+//! Issue: #164
+
+use hrafn::channels::media_pipeline::MediaAttachment;
+use hrafn::channels::traits::ChannelMessage;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 1: Handler prefix in signal content
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn channel_message_from_signal_has_handler_prefix() {
+    let msg = ChannelMessage {
+        id: "tgu_100eyes_12345".into(),
+        sender: "100eyes_crypto".into(),
+        reply_target: "@my_hrafn_bot".into(),
+        content: "[handler:trading_signal]\nBTCUSDT Long, TP 70000, SL 65000".into(),
+        channel: "telegram_user".into(),
+        timestamp: 1700000000,
+        thread_ts: None,
+        interruption_scope_id: None,
+        attachments: vec![],
+    };
+
+    assert!(msg.content.starts_with("[handler:trading_signal]"));
+    assert_eq!(msg.channel, "telegram_user");
+    assert_eq!(msg.sender, "100eyes_crypto");
+    // Reply target routes to bot, not back to the watched channel
+    assert_eq!(msg.reply_target, "@my_hrafn_bot");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 2: Message ID uniqueness per channel
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn signal_message_id_includes_channel_and_msg_id() {
+    let id1 = format!("tgu_{}_{}", "channel_a", 123);
+    let id2 = format!("tgu_{}_{}", "channel_b", 123);
+    let id3 = format!("tgu_{}_{}", "channel_a", 456);
+
+    assert_ne!(id1, id2, "different channels should produce different IDs");
+    assert_ne!(
+        id1, id3,
+        "different message IDs should produce different IDs"
+    );
+    assert!(id1.starts_with("tgu_"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 3: Image attachment structure
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn signal_with_image_attachment() {
+    let image_bytes = vec![0xFF, 0xD8, 0xFF, 0xE0]; // JPEG magic bytes
+    let attachment = MediaAttachment {
+        file_name: "signal_1700000000.jpg".to_string(),
+        data: image_bytes.clone(),
+        mime_type: Some("image/jpeg".to_string()),
+    };
+
+    let msg = ChannelMessage {
+        id: "tgu_100eyes_789".into(),
+        sender: "100eyes".into(),
+        reply_target: "@bot".into(),
+        content: "[handler:trading_signal]\nXRPUSDT Long".into(),
+        channel: "telegram_user".into(),
+        timestamp: 1700000000,
+        thread_ts: None,
+        interruption_scope_id: None,
+        attachments: vec![attachment],
+    };
+
+    assert_eq!(msg.attachments.len(), 1);
+    assert_eq!(msg.attachments[0].mime_type, Some("image/jpeg".to_string()));
+    assert!(msg.attachments[0].file_name.starts_with("signal_"));
+    assert!(msg.attachments[0].file_name.ends_with(".jpg"));
+    assert_eq!(msg.attachments[0].data, image_bytes);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 4: No handler prefix when handler is empty
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn signal_without_handler_passes_raw_text() {
+    let handler = "";
+    let text = "Some channel message";
+    let content = if handler.is_empty() {
+        text.to_string()
+    } else {
+        format!("[handler:{handler}]\n{text}")
+    };
+
+    assert!(!content.starts_with("[handler:"));
+    assert_eq!(content, "Some channel message");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 5: Channel construction from config (feature-gated)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "channel-telegram-user")]
+#[test]
+fn channel_construction_from_config() {
+    use hrafn::channels::telegram_user::TelegramUserChannel;
+    use hrafn::channels::traits::Channel;
+    use hrafn::config::{TelegramUserConfig, TelegramUserWatchConfig};
+
+    let config = TelegramUserConfig {
+        api_id: 12345,
+        api_hash: "test_hash".to_string(),
+        phone: "+1 555 0100".to_string(),
+        session_file: "/tmp/test.session".to_string(),
+        watch: vec![TelegramUserWatchConfig {
+            channel: "test_channel".to_string(),
+            handler: "trading_signal".to_string(),
+        }],
+        reply_via_bot: Some("@test_bot".to_string()),
+    };
+
+    let channel = TelegramUserChannel::new(&config);
+    assert_eq!(channel.name(), "telegram_user");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 6: send() is a no-op (feature-gated)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "channel-telegram-user")]
+#[tokio::test]
+async fn send_is_noop() {
+    use hrafn::channels::telegram_user::TelegramUserChannel;
+    use hrafn::channels::traits::{Channel, SendMessage};
+    use hrafn::config::{TelegramUserConfig, TelegramUserWatchConfig};
+
+    let config = TelegramUserConfig {
+        api_id: 12345,
+        api_hash: "test_hash".to_string(),
+        phone: "+1 555 0100".to_string(),
+        session_file: "/tmp/test.session".to_string(),
+        watch: vec![TelegramUserWatchConfig {
+            channel: "test".to_string(),
+            handler: "".to_string(),
+        }],
+        reply_via_bot: Some("@test_bot".to_string()),
+    };
+
+    let channel = TelegramUserChannel::new(&config);
+    let msg = SendMessage::new("hello", "@someone");
+
+    // send() should succeed (it's a no-op)
+    let result = channel.send(&msg).await;
+    assert!(result.is_ok());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 7: Multiple watch configs produce distinct messages
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn multiple_watch_configs_produce_distinct_messages() {
+    let channels = vec![("channel_a", "handler_1"), ("channel_b", "handler_2")];
+
+    let messages: Vec<ChannelMessage> = channels
+        .iter()
+        .enumerate()
+        .map(|(i, (ch, handler))| {
+            let text = format!("Signal from {ch}");
+            let content = format!("[handler:{handler}]\n{text}");
+            ChannelMessage {
+                id: format!("tgu_{}_{}", ch, i),
+                sender: ch.to_string(),
+                reply_target: "@bot".into(),
+                content,
+                channel: "telegram_user".into(),
+                timestamp: 1700000000 + i as u64,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+            }
+        })
+        .collect();
+
+    assert_eq!(messages.len(), 2);
+    assert_ne!(messages[0].id, messages[1].id);
+    assert_ne!(messages[0].sender, messages[1].sender);
+    assert!(messages[0].content.contains("[handler:handler_1]"));
+    assert!(messages[1].content.contains("[handler:handler_2]"));
+}


### PR DESCRIPTION
## Summary

7 integration tests for the `telegram_user` channel signal pipeline:

1. Handler prefix `[handler:trading_signal]` in message content
2. Message ID uniqueness across channels (`tgu_{channel}_{msg_id}`)
3. Image attachment structure (MediaAttachment with JPEG MIME)
4. Raw text passthrough when handler is empty
5. Channel construction from `TelegramUserConfig` (feature-gated)
6. `send()` is a no-op (feature-gated)
7. Distinct metadata per watched channel

Tests 1-4, 7 work without the `channel-telegram-user` feature flag.
Tests 5-6 require `--features channel-telegram-user`.

## Test plan

- [x] `cargo test --test test_integration telegram_user_signal --features channel-telegram-user` — 7/7 pass
- [x] `cargo test --test test_integration telegram_user_signal` — 5/5 pass (2 compile out)
- [x] `cargo clippy --features channel-telegram-user -- -D warnings` — clean
- [x] `cargo fmt --check` — formatted

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests for the telegram user channel signal pipeline: verifies message content formatting (including empty-handler cases), message ID composition and uniqueness across channels, image attachment integrity (metadata and exact bytes), distinct outputs for multiple watch configurations, and runtime behaviors for channel registration and send operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->