### PR TITLE
feat: BM25 scoring for tool_search + per-tool eager loading

### DIFF
--- a/docs/reference/api/config-reference.md
+++ b/docs/reference/api/config-reference.md
@@ -122,6 +122,75 @@ tools = ["mcp_browser_*"]
 keywords = ["browse", "navigate", "open url", "screenshot"]
 ```
 
+## `[mcp]`
+
+External MCP (Model Context Protocol) server integration. Connects the agent to external tool servers over stdio, HTTP, or SSE transports.
+
+| Key | Default | Notes |
+|---|---|---|
+| `enabled` | `false` | Enable MCP tool loading |
+| `deferred_loading` | `true` | When `true`, MCP tool schemas are NOT sent to the LLM upfront. Only lightweight stubs (name + description) appear in the system prompt. The LLM must call the built-in `tool_search` tool to fetch full schemas before invoking a deferred tool. Reduces context window overhead by ~85% with many MCP tools. |
+
+### `[[mcp.servers]]`
+
+Each entry configures one MCP server.
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `name` | `string` | _(required)_ | Display name, used as tool prefix (`<name>__<tool>`) |
+| `transport` | `"stdio"` \| `"http"` \| `"sse"` | `"stdio"` | Transport type |
+| `command` | `string` | `""` | Executable for stdio transport |
+| `args` | `[string]` | `[]` | Arguments for stdio transport |
+| `env` | `{string: string}` | `{}` | Environment variables for stdio transport |
+| `url` | `string?` | _none_ | URL for HTTP/SSE transports |
+| `headers` | `{string: string}` | `{}` | HTTP headers for HTTP/SSE transports |
+| `tool_timeout_secs` | `u64?` | _none_ | Per-call timeout in seconds |
+| `eager_tools` | `[string]` | `[]` | Tool name patterns loaded eagerly even when `deferred_loading` is `true`. Useful for high-frequency tools the LLM needs every turn without a `tool_search` roundtrip. |
+
+### `eager_tools` patterns
+
+Patterns match against the tool's prefixed name (`<server>__<tool_name>`):
+
+| Pattern | Matches |
+|---|---|
+| `"muninn_recall"` | Exact: `muninn__muninn_recall` (after server prefix) |
+| `"muninn_recall*"` | Prefix: `muninn__muninn_recall`, `muninn__muninn_recall_tree` |
+| `"*recall"` | Suffix: any tool ending in `recall` across all servers |
+| `"*recall*"` | Contains: any tool with `recall` anywhere in the name |
+| `"*"` | All tools from this server (effectively disables deferred loading for it) |
+
+Note: patterns starting with `*` are not server-prefixed (they match globally). All other patterns are automatically prefixed with `<server_name>__`.
+
+### `tool_search` and BM25
+
+When `deferred_loading` is enabled, a built-in `tool_search` tool is registered. The LLM calls it with:
+
+- `"select:name1,name2"` — fetch exact tools by prefixed name
+- Free-text keywords — returns best matches ranked by **BM25** (Okapi BM25 with k1=1.2, b=0.75)
+
+BM25 uses TF-IDF weighting so rare terms (e.g. "quantum") rank higher than common terms (e.g. "tool"). Tool names are tokenized on whitespace, underscores, and hyphens.
+
+### Example
+
+```toml
+[mcp]
+enabled = true
+deferred_loading = true
+
+[[mcp.servers]]
+name = "muninn"
+command = "muninn"
+args = ["mcp"]
+eager_tools = ["*recall*", "*remember*"]
+
+[[mcp.servers]]
+name = "filesystem"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/docs"]
+eager_tools = []
+```
+
 ## `[pacing]`
 
 Pacing controls for slow/local LLM workloads (Ollama, llama.cpp, vLLM). All keys are optional; when absent, existing behavior is preserved.

--- a/docs/setup-guides/trading-setup.md
+++ b/docs/setup-guides/trading-setup.md
@@ -129,7 +129,9 @@ Rules:
   server is reachable at the configured URL.
 - **Agent not using tools**: Check that `deferred_loading` is working — the
   agent must call `tool_search` first if deferred loading is enabled (the
-  default). Set `deferred_loading = false` to eagerly load all tool schemas.
+  default). Set `deferred_loading = false` to eagerly load all tool schemas,
+  or add frequently-needed tools to `eager_tools` on the server config so
+  they're available without a `tool_search` roundtrip.
 - **Timeout errors**: Increase `tool_timeout_secs` on the MCP server config:
   ```toml
   [[mcp.servers]]

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -444,8 +444,19 @@ impl Agent {
                 Ok(registry) => {
                     let registry = std::sync::Arc::new(registry);
                     if config.mcp.deferred_loading {
+                        // Collect eager_tools patterns from all server configs
+                        let eager_patterns: Vec<String> = config
+                            .mcp
+                            .servers
+                            .iter()
+                            .flat_map(|s| {
+                                s.eager_tools.iter().map(|p| format!("{}__{}", s.name, p))
+                            })
+                            .collect();
+
                         let deferred_set = tools::DeferredMcpToolSet::from_registry(
                             std::sync::Arc::clone(&registry),
+                            &eager_patterns,
                         )
                         .await;
                         tracing::info!(
@@ -453,6 +464,35 @@ impl Agent {
                             deferred_set.len(),
                             registry.server_count()
                         );
+
+                        // Register eager tools as normal MCP tools
+                        let all_names = registry.tool_names();
+                        let mut eager_count = 0usize;
+                        for name in &all_names {
+                            if !tools::mcp_deferred::is_eager_match(name, &eager_patterns) {
+                                continue;
+                            }
+                            if let Some(def) = registry.get_tool_def(name).await {
+                                let wrapper: std::sync::Arc<dyn tools::Tool> =
+                                    std::sync::Arc::new(tools::McpToolWrapper::new(
+                                        name.clone(),
+                                        def,
+                                        std::sync::Arc::clone(&registry),
+                                    ));
+                                if let Some(ref handle) = delegate_handle {
+                                    handle.write().push(std::sync::Arc::clone(&wrapper));
+                                }
+                                tools.push(Box::new(tools::ArcToolRef(wrapper)));
+                                eager_count += 1;
+                            }
+                        }
+                        if eager_count > 0 {
+                            tracing::info!(
+                                "MCP eager: {} tool(s) registered directly",
+                                eager_count
+                            );
+                        }
+
                         let activated =
                             Arc::new(std::sync::Mutex::new(tools::ActivatedToolSet::new()));
                         activated_tools = Some(Arc::clone(&activated));

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -450,7 +450,13 @@ impl Agent {
                             .servers
                             .iter()
                             .flat_map(|s| {
-                                s.eager_tools.iter().map(|p| format!("{}__{}", s.name, p))
+                                s.eager_tools.iter().map(|p| {
+                                    if p.starts_with('*') {
+                                        p.clone()
+                                    } else {
+                                        format!("{}__{}", s.name, p)
+                                    }
+                                })
                             })
                             .collect();
 

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -444,36 +444,19 @@ impl Agent {
                 Ok(registry) => {
                     let registry = std::sync::Arc::new(registry);
                     if config.mcp.deferred_loading {
-                        // Collect eager_tools patterns from all server configs
-                        let eager_patterns: Vec<String> = config
+                        // Build server-scoped eager patterns
+                        let server_patterns: Vec<(String, Vec<String>)> = config
                             .mcp
                             .servers
                             .iter()
-                            .flat_map(|s| {
-                                s.eager_tools.iter().map(|p| {
-                                    if p.starts_with('*') {
-                                        p.clone()
-                                    } else {
-                                        format!("{}__{}", s.name, p)
-                                    }
-                                })
-                            })
+                            .map(|s| (s.name.clone(), s.eager_tools.clone()))
                             .collect();
+                        let eager_patterns =
+                            tools::mcp_deferred::build_eager_patterns(&server_patterns);
 
-                        let deferred_set = tools::DeferredMcpToolSet::from_registry(
-                            std::sync::Arc::clone(&registry),
-                            &eager_patterns,
-                        )
-                        .await;
-                        tracing::info!(
-                            "MCP deferred: {} tool stub(s) from {} server(s)",
-                            deferred_set.len(),
-                            registry.server_count()
-                        );
-
-                        // Register eager tools as normal MCP tools
+                        // Try to load eager tools first, track which ones actually loaded
                         let all_names = registry.tool_names();
-                        let mut eager_count = 0usize;
+                        let mut eagerly_loaded: Vec<String> = Vec::new();
                         for name in &all_names {
                             if !tools::mcp_deferred::is_eager_match(name, &eager_patterns) {
                                 continue;
@@ -489,15 +472,31 @@ impl Agent {
                                     handle.write().push(std::sync::Arc::clone(&wrapper));
                                 }
                                 tools.push(Box::new(tools::ArcToolRef(wrapper)));
-                                eager_count += 1;
+                                eagerly_loaded.push(name.clone());
+                            } else {
+                                tracing::warn!(
+                                    "MCP eager: tool {name} matched pattern but get_tool_def returned None — leaving in deferred set"
+                                );
                             }
                         }
-                        if eager_count > 0 {
+                        if !eagerly_loaded.is_empty() {
                             tracing::info!(
                                 "MCP eager: {} tool(s) registered directly",
-                                eager_count
+                                eagerly_loaded.len()
                             );
                         }
+
+                        // Build deferred set excluding only successfully loaded tools
+                        let deferred_set = tools::DeferredMcpToolSet::from_registry(
+                            std::sync::Arc::clone(&registry),
+                            &eagerly_loaded,
+                        )
+                        .await;
+                        tracing::info!(
+                            "MCP deferred: {} tool stub(s) from {} server(s)",
+                            deferred_set.len(),
+                            registry.server_count()
+                        );
 
                         let activated =
                             Arc::new(std::sync::Mutex::new(tools::ActivatedToolSet::new()));

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -3617,9 +3617,18 @@ pub async fn run(
             Ok(registry) => {
                 let registry = std::sync::Arc::new(registry);
                 if config.mcp.deferred_loading {
+                    // Collect eager_tools patterns from all server configs
+                    let eager_patterns: Vec<String> = config
+                        .mcp
+                        .servers
+                        .iter()
+                        .flat_map(|s| s.eager_tools.iter().map(|p| format!("{}__{}", s.name, p)))
+                        .collect();
+
                     // Deferred path: build stubs and register tool_search
                     let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
                         std::sync::Arc::clone(&registry),
+                        &eager_patterns,
                     )
                     .await;
                     tracing::info!(
@@ -3627,6 +3636,32 @@ pub async fn run(
                         deferred_set.len(),
                         registry.server_count()
                     );
+
+                    // Register eager tools as normal MCP tools
+                    let all_names = registry.tool_names();
+                    let mut eager_count = 0usize;
+                    for name in &all_names {
+                        if !crate::tools::mcp_deferred::is_eager_match(name, &eager_patterns) {
+                            continue;
+                        }
+                        if let Some(def) = registry.get_tool_def(name).await {
+                            let wrapper: std::sync::Arc<dyn Tool> =
+                                std::sync::Arc::new(crate::tools::McpToolWrapper::new(
+                                    name.clone(),
+                                    def,
+                                    std::sync::Arc::clone(&registry),
+                                ));
+                            if let Some(ref handle) = delegate_handle {
+                                handle.write().push(std::sync::Arc::clone(&wrapper));
+                            }
+                            tools_registry.push(Box::new(crate::tools::ArcToolRef(wrapper)));
+                            eager_count += 1;
+                        }
+                    }
+                    if eager_count > 0 {
+                        tracing::info!("MCP eager: {} tool(s) registered directly", eager_count);
+                    }
+
                     deferred_section =
                         crate::tools::mcp_deferred::build_deferred_tools_section(&deferred_set);
                     let activated = std::sync::Arc::new(std::sync::Mutex::new(
@@ -4567,8 +4602,17 @@ pub async fn process_message(
             Ok(registry) => {
                 let registry = std::sync::Arc::new(registry);
                 if config.mcp.deferred_loading {
+                    // Collect eager_tools patterns from all server configs
+                    let eager_patterns: Vec<String> = config
+                        .mcp
+                        .servers
+                        .iter()
+                        .flat_map(|s| s.eager_tools.iter().map(|p| format!("{}__{}", s.name, p)))
+                        .collect();
+
                     let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
                         std::sync::Arc::clone(&registry),
+                        &eager_patterns,
                     )
                     .await;
                     tracing::info!(
@@ -4576,6 +4620,32 @@ pub async fn process_message(
                         deferred_set.len(),
                         registry.server_count()
                     );
+
+                    // Register eager tools as normal MCP tools
+                    let all_names = registry.tool_names();
+                    let mut eager_count = 0usize;
+                    for name in &all_names {
+                        if !crate::tools::mcp_deferred::is_eager_match(name, &eager_patterns) {
+                            continue;
+                        }
+                        if let Some(def) = registry.get_tool_def(name).await {
+                            let wrapper: std::sync::Arc<dyn Tool> =
+                                std::sync::Arc::new(crate::tools::McpToolWrapper::new(
+                                    name.clone(),
+                                    def,
+                                    std::sync::Arc::clone(&registry),
+                                ));
+                            if let Some(ref handle) = delegate_handle_pm {
+                                handle.write().push(std::sync::Arc::clone(&wrapper));
+                            }
+                            tools_registry.push(Box::new(crate::tools::ArcToolRef(wrapper)));
+                            eager_count += 1;
+                        }
+                    }
+                    if eager_count > 0 {
+                        tracing::info!("MCP eager: {} tool(s) registered directly", eager_count);
+                    }
+
                     deferred_section =
                         crate::tools::mcp_deferred::build_deferred_tools_section(&deferred_set);
                     let activated = std::sync::Arc::new(std::sync::Mutex::new(

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -3617,37 +3617,19 @@ pub async fn run(
             Ok(registry) => {
                 let registry = std::sync::Arc::new(registry);
                 if config.mcp.deferred_loading {
-                    // Collect eager_tools patterns from all server configs
-                    let eager_patterns: Vec<String> = config
+                    // Build server-scoped eager patterns
+                    let server_patterns: Vec<(String, Vec<String>)> = config
                         .mcp
                         .servers
                         .iter()
-                        .flat_map(|s| {
-                            s.eager_tools.iter().map(|p| {
-                                if p.starts_with('*') {
-                                    p.clone()
-                                } else {
-                                    format!("{}__{}", s.name, p)
-                                }
-                            })
-                        })
+                        .map(|s| (s.name.clone(), s.eager_tools.clone()))
                         .collect();
+                    let eager_patterns =
+                        crate::tools::mcp_deferred::build_eager_patterns(&server_patterns);
 
-                    // Deferred path: build stubs and register tool_search
-                    let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
-                        std::sync::Arc::clone(&registry),
-                        &eager_patterns,
-                    )
-                    .await;
-                    tracing::info!(
-                        "MCP deferred: {} tool stub(s) from {} server(s)",
-                        deferred_set.len(),
-                        registry.server_count()
-                    );
-
-                    // Register eager tools as normal MCP tools
+                    // Try to load eager tools first, track which ones actually loaded
                     let all_names = registry.tool_names();
-                    let mut eager_count = 0usize;
+                    let mut eagerly_loaded: Vec<String> = Vec::new();
                     for name in &all_names {
                         if !crate::tools::mcp_deferred::is_eager_match(name, &eager_patterns) {
                             continue;
@@ -3663,12 +3645,31 @@ pub async fn run(
                                 handle.write().push(std::sync::Arc::clone(&wrapper));
                             }
                             tools_registry.push(Box::new(crate::tools::ArcToolRef(wrapper)));
-                            eager_count += 1;
+                            eagerly_loaded.push(name.clone());
+                        } else {
+                            tracing::warn!(
+                                "MCP eager: tool {name} matched pattern but get_tool_def returned None — leaving in deferred set"
+                            );
                         }
                     }
-                    if eager_count > 0 {
-                        tracing::info!("MCP eager: {} tool(s) registered directly", eager_count);
+                    if !eagerly_loaded.is_empty() {
+                        tracing::info!(
+                            "MCP eager: {} tool(s) registered directly",
+                            eagerly_loaded.len()
+                        );
                     }
+
+                    // Build deferred set excluding only successfully loaded tools
+                    let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
+                        std::sync::Arc::clone(&registry),
+                        &eagerly_loaded,
+                    )
+                    .await;
+                    tracing::info!(
+                        "MCP deferred: {} tool stub(s) from {} server(s)",
+                        deferred_set.len(),
+                        registry.server_count()
+                    );
 
                     deferred_section =
                         crate::tools::mcp_deferred::build_deferred_tools_section(&deferred_set);
@@ -4610,36 +4611,19 @@ pub async fn process_message(
             Ok(registry) => {
                 let registry = std::sync::Arc::new(registry);
                 if config.mcp.deferred_loading {
-                    // Collect eager_tools patterns from all server configs
-                    let eager_patterns: Vec<String> = config
+                    // Build server-scoped eager patterns
+                    let server_patterns: Vec<(String, Vec<String>)> = config
                         .mcp
                         .servers
                         .iter()
-                        .flat_map(|s| {
-                            s.eager_tools.iter().map(|p| {
-                                if p.starts_with('*') {
-                                    p.clone()
-                                } else {
-                                    format!("{}__{}", s.name, p)
-                                }
-                            })
-                        })
+                        .map(|s| (s.name.clone(), s.eager_tools.clone()))
                         .collect();
+                    let eager_patterns =
+                        crate::tools::mcp_deferred::build_eager_patterns(&server_patterns);
 
-                    let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
-                        std::sync::Arc::clone(&registry),
-                        &eager_patterns,
-                    )
-                    .await;
-                    tracing::info!(
-                        "MCP deferred: {} tool stub(s) from {} server(s)",
-                        deferred_set.len(),
-                        registry.server_count()
-                    );
-
-                    // Register eager tools as normal MCP tools
+                    // Try to load eager tools first, track which ones actually loaded
                     let all_names = registry.tool_names();
-                    let mut eager_count = 0usize;
+                    let mut eagerly_loaded: Vec<String> = Vec::new();
                     for name in &all_names {
                         if !crate::tools::mcp_deferred::is_eager_match(name, &eager_patterns) {
                             continue;
@@ -4655,12 +4639,31 @@ pub async fn process_message(
                                 handle.write().push(std::sync::Arc::clone(&wrapper));
                             }
                             tools_registry.push(Box::new(crate::tools::ArcToolRef(wrapper)));
-                            eager_count += 1;
+                            eagerly_loaded.push(name.clone());
+                        } else {
+                            tracing::warn!(
+                                "MCP eager: tool {name} matched pattern but get_tool_def returned None — leaving in deferred set"
+                            );
                         }
                     }
-                    if eager_count > 0 {
-                        tracing::info!("MCP eager: {} tool(s) registered directly", eager_count);
+                    if !eagerly_loaded.is_empty() {
+                        tracing::info!(
+                            "MCP eager: {} tool(s) registered directly",
+                            eagerly_loaded.len()
+                        );
                     }
+
+                    // Build deferred set excluding only successfully loaded tools
+                    let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
+                        std::sync::Arc::clone(&registry),
+                        &eagerly_loaded,
+                    )
+                    .await;
+                    tracing::info!(
+                        "MCP deferred: {} tool stub(s) from {} server(s)",
+                        deferred_set.len(),
+                        registry.server_count()
+                    );
 
                     deferred_section =
                         crate::tools::mcp_deferred::build_deferred_tools_section(&deferred_set);

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -3622,7 +3622,15 @@ pub async fn run(
                         .mcp
                         .servers
                         .iter()
-                        .flat_map(|s| s.eager_tools.iter().map(|p| format!("{}__{}", s.name, p)))
+                        .flat_map(|s| {
+                            s.eager_tools.iter().map(|p| {
+                                if p.starts_with('*') {
+                                    p.clone()
+                                } else {
+                                    format!("{}__{}", s.name, p)
+                                }
+                            })
+                        })
                         .collect();
 
                     // Deferred path: build stubs and register tool_search
@@ -4607,7 +4615,15 @@ pub async fn process_message(
                         .mcp
                         .servers
                         .iter()
-                        .flat_map(|s| s.eager_tools.iter().map(|p| format!("{}__{}", s.name, p)))
+                        .flat_map(|s| {
+                            s.eager_tools.iter().map(|p| {
+                                if p.starts_with('*') {
+                                    p.clone()
+                                } else {
+                                    format!("{}__{}", s.name, p)
+                                }
+                            })
+                        })
                         .collect();
 
                     let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -5234,8 +5234,17 @@ pub async fn start_channels(config: Config) -> Result<()> {
             Ok(registry) => {
                 let registry = std::sync::Arc::new(registry);
                 if config.mcp.deferred_loading {
+                    // Collect eager_tools patterns from all server configs
+                    let eager_patterns: Vec<String> = config
+                        .mcp
+                        .servers
+                        .iter()
+                        .flat_map(|s| s.eager_tools.iter().map(|p| format!("{}__{}", s.name, p)))
+                        .collect();
+
                     let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
                         std::sync::Arc::clone(&registry),
+                        &eager_patterns,
                     )
                     .await;
                     tracing::info!(
@@ -5243,6 +5252,24 @@ pub async fn start_channels(config: Config) -> Result<()> {
                         deferred_set.len(),
                         registry.server_count()
                     );
+
+                    // Register eager tools as normal MCP tools
+                    let all_names = registry.tool_names();
+                    for name in &all_names {
+                        if !crate::tools::mcp_deferred::is_eager_match(name, &eager_patterns) {
+                            continue;
+                        }
+                        if let Some(def) = registry.get_tool_def(name).await {
+                            let wrapper: std::sync::Arc<dyn crate::tools::Tool> =
+                                std::sync::Arc::new(crate::tools::McpToolWrapper::new(
+                                    name.clone(),
+                                    def,
+                                    std::sync::Arc::clone(&registry),
+                                ));
+                            built_tools.push(Box::new(crate::tools::ArcToolRef(wrapper)));
+                        }
+                    }
+
                     deferred_section =
                         crate::tools::mcp_deferred::build_deferred_tools_section(&deferred_set);
                     let activated = std::sync::Arc::new(std::sync::Mutex::new(

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -5234,35 +5234,19 @@ pub async fn start_channels(config: Config) -> Result<()> {
             Ok(registry) => {
                 let registry = std::sync::Arc::new(registry);
                 if config.mcp.deferred_loading {
-                    // Collect eager_tools patterns from all server configs
-                    let eager_patterns: Vec<String> = config
+                    // Build server-scoped eager patterns
+                    let server_patterns: Vec<(String, Vec<String>)> = config
                         .mcp
                         .servers
                         .iter()
-                        .flat_map(|s| {
-                            s.eager_tools.iter().map(|p| {
-                                if p.starts_with('*') {
-                                    p.clone()
-                                } else {
-                                    format!("{}__{}", s.name, p)
-                                }
-                            })
-                        })
+                        .map(|s| (s.name.clone(), s.eager_tools.clone()))
                         .collect();
+                    let eager_patterns =
+                        crate::tools::mcp_deferred::build_eager_patterns(&server_patterns);
 
-                    let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
-                        std::sync::Arc::clone(&registry),
-                        &eager_patterns,
-                    )
-                    .await;
-                    tracing::info!(
-                        "MCP deferred: {} tool stub(s) from {} server(s)",
-                        deferred_set.len(),
-                        registry.server_count()
-                    );
-
-                    // Register eager tools as normal MCP tools
+                    // Try to load eager tools first, track which ones actually loaded
                     let all_names = registry.tool_names();
+                    let mut eagerly_loaded: Vec<String> = Vec::new();
                     for name in &all_names {
                         if !crate::tools::mcp_deferred::is_eager_match(name, &eager_patterns) {
                             continue;
@@ -5274,9 +5258,35 @@ pub async fn start_channels(config: Config) -> Result<()> {
                                     def,
                                     std::sync::Arc::clone(&registry),
                                 ));
+                            if let Some(ref handle) = delegate_handle_ch {
+                                handle.write().push(std::sync::Arc::clone(&wrapper));
+                            }
                             built_tools.push(Box::new(crate::tools::ArcToolRef(wrapper)));
+                            eagerly_loaded.push(name.clone());
+                        } else {
+                            tracing::warn!(
+                                "MCP eager: tool {name} matched pattern but get_tool_def returned None — leaving in deferred set"
+                            );
                         }
                     }
+                    if !eagerly_loaded.is_empty() {
+                        tracing::info!(
+                            "MCP eager: {} tool(s) registered directly",
+                            eagerly_loaded.len()
+                        );
+                    }
+
+                    // Build deferred set excluding only successfully loaded tools
+                    let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
+                        std::sync::Arc::clone(&registry),
+                        &eagerly_loaded,
+                    )
+                    .await;
+                    tracing::info!(
+                        "MCP deferred: {} tool stub(s) from {} server(s)",
+                        deferred_set.len(),
+                        registry.server_count()
+                    );
 
                     deferred_section =
                         crate::tools::mcp_deferred::build_deferred_tools_section(&deferred_set);

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -5239,7 +5239,15 @@ pub async fn start_channels(config: Config) -> Result<()> {
                         .mcp
                         .servers
                         .iter()
-                        .flat_map(|s| s.eager_tools.iter().map(|p| format!("{}__{}", s.name, p)))
+                        .flat_map(|s| {
+                            s.eager_tools.iter().map(|p| {
+                                if p.starts_with('*') {
+                                    p.clone()
+                                } else {
+                                    format!("{}__{}", s.name, p)
+                                }
+                            })
+                        })
                         .collect();
 
                     let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -948,6 +948,11 @@ pub struct McpServerConfig {
     /// Optional per-call timeout in seconds (hard capped in validation).
     #[serde(default)]
     pub tool_timeout_secs: Option<u64>,
+    /// Tool names (or glob patterns) that should be loaded eagerly even when
+    /// `deferred_loading` is true. Useful for high-frequency tools like memory
+    /// or shell that the LLM needs on every turn without a tool_search roundtrip.
+    #[serde(default)]
+    pub eager_tools: Vec<String>,
 }
 
 /// External MCP client configuration (`[mcp]` section).

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -512,14 +512,42 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
             Ok(registry) => {
                 let registry = std::sync::Arc::new(registry);
                 if config.mcp.deferred_loading {
-                    let deferred_set =
-                        tools::DeferredMcpToolSet::from_registry(std::sync::Arc::clone(&registry))
-                            .await;
+                    // Collect eager_tools patterns from all server configs
+                    let eager_patterns: Vec<String> = config
+                        .mcp
+                        .servers
+                        .iter()
+                        .flat_map(|s| s.eager_tools.iter().map(|p| format!("{}__{}", s.name, p)))
+                        .collect();
+
+                    let deferred_set = tools::DeferredMcpToolSet::from_registry(
+                        std::sync::Arc::clone(&registry),
+                        &eager_patterns,
+                    )
+                    .await;
                     tracing::info!(
                         "Gateway MCP deferred: {} tool stub(s) from {} server(s)",
                         deferred_set.len(),
                         registry.server_count()
                     );
+
+                    // Register eager tools as normal MCP tools
+                    let all_names = registry.tool_names();
+                    for name in &all_names {
+                        if !tools::mcp_deferred::is_eager_match(name, &eager_patterns) {
+                            continue;
+                        }
+                        if let Some(def) = registry.get_tool_def(name).await {
+                            let wrapper: std::sync::Arc<dyn tools::Tool> =
+                                std::sync::Arc::new(tools::McpToolWrapper::new(
+                                    name.clone(),
+                                    def,
+                                    std::sync::Arc::clone(&registry),
+                                ));
+                            tools_registry_raw.push(Box::new(tools::ArcToolRef(wrapper)));
+                        }
+                    }
+
                     let activated =
                         std::sync::Arc::new(std::sync::Mutex::new(tools::ActivatedToolSet::new()));
                     tools_registry_raw.push(Box::new(tools::ToolSearchTool::new(

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -517,7 +517,15 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
                         .mcp
                         .servers
                         .iter()
-                        .flat_map(|s| s.eager_tools.iter().map(|p| format!("{}__{}", s.name, p)))
+                        .flat_map(|s| {
+                            s.eager_tools.iter().map(|p| {
+                                if p.starts_with('*') {
+                                    p.clone()
+                                } else {
+                                    format!("{}__{}", s.name, p)
+                                }
+                            })
+                        })
                         .collect();
 
                     let deferred_set = tools::DeferredMcpToolSet::from_registry(

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -512,35 +512,19 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
             Ok(registry) => {
                 let registry = std::sync::Arc::new(registry);
                 if config.mcp.deferred_loading {
-                    // Collect eager_tools patterns from all server configs
-                    let eager_patterns: Vec<String> = config
+                    // Build server-scoped eager patterns
+                    let server_patterns: Vec<(String, Vec<String>)> = config
                         .mcp
                         .servers
                         .iter()
-                        .flat_map(|s| {
-                            s.eager_tools.iter().map(|p| {
-                                if p.starts_with('*') {
-                                    p.clone()
-                                } else {
-                                    format!("{}__{}", s.name, p)
-                                }
-                            })
-                        })
+                        .map(|s| (s.name.clone(), s.eager_tools.clone()))
                         .collect();
+                    let eager_patterns =
+                        tools::mcp_deferred::build_eager_patterns(&server_patterns);
 
-                    let deferred_set = tools::DeferredMcpToolSet::from_registry(
-                        std::sync::Arc::clone(&registry),
-                        &eager_patterns,
-                    )
-                    .await;
-                    tracing::info!(
-                        "Gateway MCP deferred: {} tool stub(s) from {} server(s)",
-                        deferred_set.len(),
-                        registry.server_count()
-                    );
-
-                    // Register eager tools as normal MCP tools
+                    // Try to load eager tools first, track which ones actually loaded
                     let all_names = registry.tool_names();
+                    let mut eagerly_loaded: Vec<String> = Vec::new();
                     for name in &all_names {
                         if !tools::mcp_deferred::is_eager_match(name, &eager_patterns) {
                             continue;
@@ -552,9 +536,35 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
                                     def,
                                     std::sync::Arc::clone(&registry),
                                 ));
+                            if let Some(ref handle) = delegate_handle_gw {
+                                handle.write().push(std::sync::Arc::clone(&wrapper));
+                            }
                             tools_registry_raw.push(Box::new(tools::ArcToolRef(wrapper)));
+                            eagerly_loaded.push(name.clone());
+                        } else {
+                            tracing::warn!(
+                                "MCP eager: tool {name} matched pattern but get_tool_def returned None — leaving in deferred set"
+                            );
                         }
                     }
+                    if !eagerly_loaded.is_empty() {
+                        tracing::info!(
+                            "Gateway MCP eager: {} tool(s) registered directly",
+                            eagerly_loaded.len()
+                        );
+                    }
+
+                    // Build deferred set excluding only successfully loaded tools
+                    let deferred_set = tools::DeferredMcpToolSet::from_registry(
+                        std::sync::Arc::clone(&registry),
+                        &eagerly_loaded,
+                    )
+                    .await;
+                    tracing::info!(
+                        "Gateway MCP deferred: {} tool stub(s) from {} server(s)",
+                        deferred_set.len(),
+                        registry.server_count()
+                    );
 
                     let activated =
                         std::sync::Arc::new(std::sync::Mutex::new(tools::ActivatedToolSet::new()));

--- a/src/tools/mcp_client.rs
+++ b/src/tools/mcp_client.rs
@@ -316,6 +316,7 @@ mod tests {
             transport: McpTransport::Stdio,
             url: None,
             headers: std::collections::HashMap::default(),
+            eager_tools: vec![],
         };
         let result = McpServer::connect(config).await;
         assert!(result.is_err());
@@ -335,6 +336,7 @@ mod tests {
             transport: McpTransport::Stdio,
             url: None,
             headers: std::collections::HashMap::default(),
+            eager_tools: vec![],
         }];
         let registry = McpRegistry::connect_all(&configs)
             .await

--- a/src/tools/mcp_deferred.rs
+++ b/src/tools/mcp_deferred.rs
@@ -14,6 +14,114 @@ use crate::tools::mcp_protocol::McpToolDef;
 use crate::tools::mcp_tool::McpToolWrapper;
 use crate::tools::traits::{Tool, ToolSpec};
 
+// ── BM25 Index ──────────────────────────────────────────────────────────
+
+/// Precomputed corpus statistics for BM25 scoring.
+struct BM25Index {
+    /// Tokenized documents (one per stub, same order as `stubs`).
+    docs: Vec<Vec<String>>,
+    /// Document lengths (in tokens).
+    doc_lengths: Vec<f64>,
+    /// Average document length across the corpus.
+    avgdl: f64,
+    /// Number of documents containing each term.
+    doc_freq: HashMap<String, usize>,
+    /// Total number of documents.
+    n: usize,
+}
+
+impl BM25Index {
+    const K1: f64 = 1.2;
+    const B: f64 = 0.75;
+
+    /// Build the index from stub name+description pairs.
+    fn build(stubs: &[DeferredMcpToolStub]) -> Self {
+        let n = stubs.len();
+        let mut docs = Vec::with_capacity(n);
+        let mut doc_lengths = Vec::with_capacity(n);
+        let mut doc_freq: HashMap<String, usize> = HashMap::new();
+
+        for stub in stubs {
+            let tokens = Self::tokenize(&stub.prefixed_name, &stub.description);
+            doc_lengths.push(tokens.len() as f64);
+
+            // Count unique terms per document for doc frequency
+            let mut seen = std::collections::HashSet::new();
+            for token in &tokens {
+                if seen.insert(token.clone()) {
+                    *doc_freq.entry(token.clone()).or_insert(0) += 1;
+                }
+            }
+            docs.push(tokens);
+        }
+
+        let total_len: f64 = doc_lengths.iter().sum();
+        let avgdl = if n > 0 { total_len / n as f64 } else { 1.0 };
+
+        Self {
+            docs,
+            doc_lengths,
+            avgdl,
+            doc_freq,
+            n,
+        }
+    }
+
+    /// Tokenize a name and description into lowercase terms, splitting on
+    /// whitespace, underscores, and hyphens.
+    fn tokenize(name: &str, description: &str) -> Vec<String> {
+        let combined = format!("{} {}", name, description);
+        combined
+            .split(|c: char| c.is_whitespace() || c == '_' || c == '-')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_ascii_lowercase())
+            .collect()
+    }
+
+    /// Check if a query term matches a document token.
+    /// Matches if either starts with the other (handles "file"/"files" variants).
+    #[inline]
+    fn term_matches(query_term: &str, doc_token: &str) -> bool {
+        doc_token.starts_with(query_term) || query_term.starts_with(doc_token)
+    }
+
+    /// Score a query against document at `doc_idx`.
+    /// Uses prefix matching for term frequency to handle morphological
+    /// variants (e.g. "file" matches "files" and vice versa).
+    fn score(&self, query_terms: &[String], doc_idx: usize) -> f64 {
+        let dl = self.doc_lengths[doc_idx];
+        let doc = &self.docs[doc_idx];
+        let mut total = 0.0f64;
+
+        for qt in query_terms {
+            // Term frequency: count doc tokens that prefix-match the query term
+            let tf = doc.iter().filter(|t| Self::term_matches(qt, t)).count() as f64;
+            if tf == 0.0 {
+                continue;
+            }
+
+            // IDF: ln((N - n(q) + 0.5) / (n(q) + 0.5) + 1)
+            // Use exact doc_freq if available, else compute via prefix matching
+            let nq = match self.doc_freq.get(qt) {
+                Some(&n) => n as f64,
+                None => self
+                    .docs
+                    .iter()
+                    .filter(|d| d.iter().any(|t| Self::term_matches(qt, t)))
+                    .count() as f64,
+            };
+            let idf = ((self.n as f64 - nq + 0.5) / (nq + 0.5) + 1.0).ln();
+
+            // BM25 term score
+            let numerator = tf * (Self::K1 + 1.0);
+            let denominator = tf + Self::K1 * (1.0 - Self::B + Self::B * dl / self.avgdl);
+            total += idf * numerator / denominator;
+        }
+
+        total
+    }
+}
+
 // ── DeferredMcpToolStub ──────────────────────────────────────────────────
 
 /// A lightweight stub representing a known-but-not-yet-loaded MCP tool.
@@ -51,26 +159,47 @@ impl DeferredMcpToolStub {
 // ── DeferredMcpToolSet ───────────────────────────────────────────────────
 
 /// Collection of all deferred MCP tool stubs discovered at startup.
-/// Provides keyword search for `tool_search`.
+/// Provides BM25-ranked keyword search for `tool_search`.
 #[derive(Clone)]
 pub struct DeferredMcpToolSet {
     /// All stubs — exposed for test construction.
     pub stubs: Vec<DeferredMcpToolStub>,
     /// Shared registry — exposed for test construction.
     pub registry: Arc<McpRegistry>,
+    /// Precomputed BM25 index over stub names + descriptions.
+    bm25: Arc<BM25Index>,
 }
 
 impl DeferredMcpToolSet {
-    /// Build the set from a connected [`McpRegistry`].
-    pub async fn from_registry(registry: Arc<McpRegistry>) -> Self {
+    /// Build the set from a connected [`McpRegistry`], excluding tools whose
+    /// prefixed names match any of the `eager_patterns` globs.
+    pub async fn from_registry(registry: Arc<McpRegistry>, eager_patterns: &[String]) -> Self {
         let names = registry.tool_names();
         let mut stubs = Vec::with_capacity(names.len());
         for name in names {
+            if is_eager_match(&name, eager_patterns) {
+                continue;
+            }
             if let Some(def) = registry.get_tool_def(&name).await {
                 stubs.push(DeferredMcpToolStub::new(name, def));
             }
         }
-        Self { stubs, registry }
+        let bm25 = Arc::new(BM25Index::build(&stubs));
+        Self {
+            stubs,
+            registry,
+            bm25,
+        }
+    }
+
+    /// Build from pre-constructed stubs (for tests and internal use).
+    pub(crate) fn from_stubs(stubs: Vec<DeferredMcpToolStub>, registry: Arc<McpRegistry>) -> Self {
+        let bm25 = Arc::new(BM25Index::build(&stubs));
+        Self {
+            stubs,
+            registry,
+            bm25,
+        }
     }
 
     /// All stub names (for rendering in the system prompt).
@@ -96,40 +225,31 @@ impl DeferredMcpToolSet {
         self.stubs.iter().find(|s| s.prefixed_name == name)
     }
 
-    /// Keyword search — returns stubs whose name or description contains any
-    /// of the query terms (case-insensitive). Results are ranked by number of
-    /// matching terms (descending).
+    /// BM25 keyword search — returns stubs ranked by Okapi BM25 relevance.
+    /// Query is tokenized on whitespace, underscores, and hyphens.
     pub fn search(&self, query: &str, max_results: usize) -> Vec<&DeferredMcpToolStub> {
         let terms: Vec<String> = query
-            .split_whitespace()
+            .split(|c: char| c.is_whitespace() || c == '_' || c == '-')
+            .filter(|s| !s.is_empty())
             .map(|t| t.to_ascii_lowercase())
             .collect();
         if terms.is_empty() {
             return self.stubs.iter().take(max_results).collect();
         }
 
-        let mut scored: Vec<(&DeferredMcpToolStub, usize)> = self
+        let mut scored: Vec<(usize, f64)> = self
             .stubs
             .iter()
-            .filter_map(|stub| {
-                let haystack = format!(
-                    "{} {}",
-                    stub.prefixed_name.to_ascii_lowercase(),
-                    stub.description.to_ascii_lowercase()
-                );
-                let hits = terms
-                    .iter()
-                    .filter(|t| haystack.contains(t.as_str()))
-                    .count();
-                if hits > 0 { Some((stub, hits)) } else { None }
-            })
+            .enumerate()
+            .map(|(idx, _)| (idx, self.bm25.score(&terms, idx)))
+            .filter(|(_, score)| *score > 0.0)
             .collect();
 
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         scored
             .into_iter()
             .take(max_results)
-            .map(|(s, _)| s)
+            .map(|(idx, _)| &self.stubs[idx])
             .collect()
     }
 
@@ -148,6 +268,24 @@ impl DeferredMcpToolSet {
             wrapper.spec()
         })
     }
+}
+
+// ── Eager tool matching ──────────────────────────────────────────────────
+
+/// Check if a tool's prefixed name matches any of the eager patterns.
+/// Supports simple glob: `*` at start/end, or exact match.
+pub fn is_eager_match(name: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|pat| {
+        if pat == "*" {
+            true
+        } else if let Some(suffix) = pat.strip_prefix('*') {
+            name.ends_with(suffix)
+        } else if let Some(prefix) = pat.strip_suffix('*') {
+            name.starts_with(prefix)
+        } else {
+            name == pat
+        }
+    })
 }
 
 // ── ActivatedToolSet ─────────────────────────────────────────────────────
@@ -266,6 +404,17 @@ mod tests {
             input_schema: serde_json::json!({"type": "object", "properties": {}}),
         };
         DeferredMcpToolStub::new(name.to_string(), def)
+    }
+
+    /// Helper to build a test DeferredMcpToolSet with BM25 index.
+    fn make_set(stubs: Vec<DeferredMcpToolStub>) -> DeferredMcpToolSet {
+        let registry = std::sync::Arc::new(
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(McpRegistry::connect_all(&[]))
+                .unwrap(),
+        );
+        DeferredMcpToolSet::from_stubs(stubs, registry)
     }
 
     #[test]
@@ -390,33 +539,16 @@ mod tests {
 
     #[test]
     fn build_deferred_section_empty_when_no_stubs() {
-        let set = DeferredMcpToolSet {
-            stubs: vec![],
-            registry: std::sync::Arc::new(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(McpRegistry::connect_all(&[]))
-                    .unwrap(),
-            ),
-        };
+        let set = make_set(vec![]);
         assert!(build_deferred_tools_section(&set).is_empty());
     }
 
     #[test]
     fn build_deferred_section_lists_names() {
-        let stubs = vec![
+        let set = make_set(vec![
             make_stub("fs__read_file", "Read a file"),
             make_stub("git__status", "Git status"),
-        ];
-        let set = DeferredMcpToolSet {
-            stubs,
-            registry: std::sync::Arc::new(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(McpRegistry::connect_all(&[]))
-                    .unwrap(),
-            ),
-        };
+        ]);
         let section = build_deferred_tools_section(&set);
         assert!(section.contains("<available-deferred-tools>"));
         assert!(section.contains("fs__read_file - Read a file"));
@@ -426,16 +558,7 @@ mod tests {
 
     #[test]
     fn build_deferred_section_includes_tool_search_instruction() {
-        let stubs = vec![make_stub("fs__read_file", "Read a file")];
-        let set = DeferredMcpToolSet {
-            stubs,
-            registry: std::sync::Arc::new(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(McpRegistry::connect_all(&[]))
-                    .unwrap(),
-            ),
-        };
+        let set = make_set(vec![make_stub("fs__read_file", "Read a file")]);
         let section = build_deferred_tools_section(&set);
         assert!(
             section.contains("tool_search"),
@@ -449,20 +572,11 @@ mod tests {
 
     #[test]
     fn build_deferred_section_multiple_servers() {
-        let stubs = vec![
+        let set = make_set(vec![
             make_stub("server_a__list", "List items"),
             make_stub("server_a__create", "Create item"),
             make_stub("server_b__query", "Query records"),
-        ];
-        let set = DeferredMcpToolSet {
-            stubs,
-            registry: std::sync::Arc::new(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(McpRegistry::connect_all(&[]))
-                    .unwrap(),
-            ),
-        };
+        ]);
         let section = build_deferred_tools_section(&set);
         assert!(section.contains("server_a__list"));
         assert!(section.contains("server_a__create"));
@@ -474,62 +588,59 @@ mod tests {
     }
 
     #[test]
-    fn keyword_search_ranks_by_hits() {
-        let stubs = vec![
+    fn keyword_search_ranks_by_bm25() {
+        let set = make_set(vec![
             make_stub("fs__read_file", "Read a file from disk"),
             make_stub("fs__write_file", "Write a file to disk"),
             make_stub("git__log", "Show git log"),
-        ];
-        let set = DeferredMcpToolSet {
-            stubs,
-            registry: std::sync::Arc::new(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(McpRegistry::connect_all(&[]))
-                    .unwrap(),
-            ),
-        };
+        ]);
 
-        // "file read" should rank fs__read_file highest (2 hits vs 1)
+        // "file read" should rank fs__read_file highest (both terms match)
         let results = set.search("file read", 5);
         assert!(!results.is_empty());
         assert_eq!(results[0].prefixed_name, "fs__read_file");
     }
 
     #[test]
+    fn bm25_ranks_rare_term_higher() {
+        // "quantum" appears in only one doc, "tool" in all — BM25 should rank
+        // the rare-term match higher than common-term matches.
+        let set = make_set(vec![
+            make_stub("srv__alpha", "A common tool for tasks"),
+            make_stub("srv__beta", "Another common tool for tasks"),
+            make_stub("srv__gamma", "Quantum physics simulator tool"),
+        ]);
+
+        let results = set.search("quantum", 5);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].prefixed_name, "srv__gamma");
+
+        // "tool" matches all 3 but with low IDF
+        let results = set.search("tool", 5);
+        assert_eq!(results.len(), 3);
+
+        // "quantum tool" should still rank gamma first (rare term dominates)
+        let results = set.search("quantum tool", 5);
+        assert!(!results.is_empty());
+        assert_eq!(results[0].prefixed_name, "srv__gamma");
+    }
+
+    #[test]
     fn get_by_name_returns_correct_stub() {
-        let stubs = vec![
+        let set = make_set(vec![
             make_stub("a__one", "Tool one"),
             make_stub("b__two", "Tool two"),
-        ];
-        let set = DeferredMcpToolSet {
-            stubs,
-            registry: std::sync::Arc::new(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(McpRegistry::connect_all(&[]))
-                    .unwrap(),
-            ),
-        };
+        ]);
         assert!(set.get_by_name("a__one").is_some());
         assert!(set.get_by_name("nonexistent").is_none());
     }
 
     #[test]
     fn search_across_multiple_servers() {
-        let stubs = vec![
+        let set = make_set(vec![
             make_stub("server_a__read_file", "Read a file from disk"),
             make_stub("server_b__read_config", "Read configuration from database"),
-        ];
-        let set = DeferredMcpToolSet {
-            stubs,
-            registry: std::sync::Arc::new(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(McpRegistry::connect_all(&[]))
-                    .unwrap(),
-            ),
-        };
+        ]);
 
         // "read" should match stubs from both servers
         let results = set.search("read", 10);
@@ -540,9 +651,38 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].prefixed_name, "server_a__read_file");
 
-        // "config database" should rank server_b highest (2 hits)
+        // "config database" should rank server_b highest (both terms match)
         let results = set.search("config database", 10);
         assert!(!results.is_empty());
         assert_eq!(results[0].prefixed_name, "server_b__read_config");
+    }
+
+    #[test]
+    fn eager_match_exact() {
+        let patterns = vec!["muninn__recall".to_string()];
+        assert!(is_eager_match("muninn__recall", &patterns));
+        assert!(!is_eager_match("muninn__remember", &patterns));
+    }
+
+    #[test]
+    fn eager_match_prefix_glob() {
+        let patterns = vec!["muninn__*".to_string()];
+        assert!(is_eager_match("muninn__recall", &patterns));
+        assert!(is_eager_match("muninn__remember", &patterns));
+        assert!(!is_eager_match("git__status", &patterns));
+    }
+
+    #[test]
+    fn eager_match_suffix_glob() {
+        let patterns = vec!["*__recall".to_string()];
+        assert!(is_eager_match("muninn__recall", &patterns));
+        assert!(is_eager_match("other__recall", &patterns));
+        assert!(!is_eager_match("muninn__remember", &patterns));
+    }
+
+    #[test]
+    fn eager_match_wildcard_all() {
+        let patterns = vec!["*".to_string()];
+        assert!(is_eager_match("anything", &patterns));
     }
 }

--- a/src/tools/mcp_deferred.rs
+++ b/src/tools/mcp_deferred.rs
@@ -273,11 +273,19 @@ impl DeferredMcpToolSet {
 // ── Eager tool matching ──────────────────────────────────────────────────
 
 /// Check if a tool's prefixed name matches any of the eager patterns.
-/// Supports simple glob: `*` at start/end, or exact match.
+/// Supports simple glob: `*` at start/end/both, or exact match.
+/// - `"*"` matches everything
+/// - `"*suffix"` matches names ending with `suffix`
+/// - `"prefix*"` matches names starting with `prefix`
+/// - `"*infix*"` matches names containing `infix`
 pub fn is_eager_match(name: &str, patterns: &[String]) -> bool {
     patterns.iter().any(|pat| {
         if pat == "*" {
             true
+        } else if pat.starts_with('*') && pat.ends_with('*') && pat.len() > 2 {
+            // *infix* — contains match
+            let infix = &pat[1..pat.len() - 1];
+            name.contains(infix)
         } else if let Some(suffix) = pat.strip_prefix('*') {
             name.ends_with(suffix)
         } else if let Some(prefix) = pat.strip_suffix('*') {
@@ -678,6 +686,14 @@ mod tests {
         assert!(is_eager_match("muninn__recall", &patterns));
         assert!(is_eager_match("other__recall", &patterns));
         assert!(!is_eager_match("muninn__remember", &patterns));
+    }
+
+    #[test]
+    fn eager_match_infix_glob() {
+        let patterns = vec!["*recall*".to_string()];
+        assert!(is_eager_match("muninn__muninn_recall", &patterns));
+        assert!(is_eager_match("muninn__muninn_recall_tree", &patterns));
+        assert!(!is_eager_match("muninn__muninn_remember", &patterns));
     }
 
     #[test]

--- a/src/tools/mcp_deferred.rs
+++ b/src/tools/mcp_deferred.rs
@@ -85,34 +85,38 @@ impl BM25Index {
         doc_token.starts_with(query_term) || query_term.starts_with(doc_token)
     }
 
+    /// Precompute IDF values for query terms. Called once per search() to avoid
+    /// repeated full-corpus scans inside score().
+    fn precompute_idfs(&self, query_terms: &[String]) -> Vec<f64> {
+        query_terms
+            .iter()
+            .map(|qt| {
+                let nq = match self.doc_freq.get(qt) {
+                    Some(&n) => n as f64,
+                    None => self
+                        .docs
+                        .iter()
+                        .filter(|d| d.iter().any(|t| Self::term_matches(qt, t)))
+                        .count() as f64,
+                };
+                ((self.n as f64 - nq + 0.5) / (nq + 0.5) + 1.0).ln()
+            })
+            .collect()
+    }
+
     /// Score a query against document at `doc_idx`.
     /// Uses prefix matching for term frequency to handle morphological
     /// variants (e.g. "file" matches "files" and vice versa).
-    fn score(&self, query_terms: &[String], doc_idx: usize) -> f64 {
+    fn score(&self, query_terms: &[String], idfs: &[f64], doc_idx: usize) -> f64 {
         let dl = self.doc_lengths[doc_idx];
         let doc = &self.docs[doc_idx];
         let mut total = 0.0f64;
 
-        for qt in query_terms {
-            // Term frequency: count doc tokens that prefix-match the query term
+        for (qt, &idf) in query_terms.iter().zip(idfs) {
             let tf = doc.iter().filter(|t| Self::term_matches(qt, t)).count() as f64;
             if tf == 0.0 {
                 continue;
             }
-
-            // IDF: ln((N - n(q) + 0.5) / (n(q) + 0.5) + 1)
-            // Use exact doc_freq if available, else compute via prefix matching
-            let nq = match self.doc_freq.get(qt) {
-                Some(&n) => n as f64,
-                None => self
-                    .docs
-                    .iter()
-                    .filter(|d| d.iter().any(|t| Self::term_matches(qt, t)))
-                    .count() as f64,
-            };
-            let idf = ((self.n as f64 - nq + 0.5) / (nq + 0.5) + 1.0).ln();
-
-            // BM25 term score
             let numerator = tf * (Self::K1 + 1.0);
             let denominator = tf + Self::K1 * (1.0 - Self::B + Self::B * dl / self.avgdl);
             total += idf * numerator / denominator;
@@ -237,15 +241,26 @@ impl DeferredMcpToolSet {
             return self.stubs.iter().take(max_results).collect();
         }
 
+        let idfs = self.bm25.precompute_idfs(&terms);
+
         let mut scored: Vec<(usize, f64)> = self
             .stubs
             .iter()
             .enumerate()
-            .map(|(idx, _)| (idx, self.bm25.score(&terms, idx)))
+            .map(|(idx, _)| (idx, self.bm25.score(&terms, &idfs, idx)))
             .filter(|(_, score)| *score > 0.0)
             .collect();
 
-        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        // Sort by score descending, then by name ascending for deterministic tie-breaking.
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| {
+                    self.stubs[a.0]
+                        .prefixed_name
+                        .cmp(&self.stubs[b.0].prefixed_name)
+                })
+        });
         scored
             .into_iter()
             .take(max_results)
@@ -272,27 +287,66 @@ impl DeferredMcpToolSet {
 
 // ── Eager tool matching ──────────────────────────────────────────────────
 
+/// Build server-scoped eager patterns from per-server config.
+/// Each pattern is prefixed with `server__` so it matches the prefixed tool name.
+pub fn build_eager_patterns(servers: &[(String, Vec<String>)]) -> Vec<String> {
+    servers
+        .iter()
+        .flat_map(|(server_name, patterns)| {
+            patterns
+                .iter()
+                .map(move |p| format!("{}__{}", server_name, p))
+        })
+        .collect()
+}
+
 /// Check if a tool's prefixed name matches any of the eager patterns.
-/// Supports simple glob: `*` at start/end/both, or exact match.
+/// Supports simple glob matching with `*` wildcards:
 /// - `"*"` matches everything
 /// - `"*suffix"` matches names ending with `suffix`
 /// - `"prefix*"` matches names starting with `prefix`
 /// - `"*infix*"` matches names containing `infix`
+/// - `"prefix*infix*"` matches names starting with `prefix` and containing `infix` after it
+///
+/// General rule: split on `*`, check that all literal segments appear in order.
+/// The first segment must be a prefix; the last segment must be a suffix;
+/// interior segments must appear (in order) anywhere in between.
 pub fn is_eager_match(name: &str, patterns: &[String]) -> bool {
     patterns.iter().any(|pat| {
-        if pat == "*" {
-            true
-        } else if pat.starts_with('*') && pat.ends_with('*') && pat.len() > 2 {
-            // *infix* — contains match
-            let infix = &pat[1..pat.len() - 1];
-            name.contains(infix)
-        } else if let Some(suffix) = pat.strip_prefix('*') {
-            name.ends_with(suffix)
-        } else if let Some(prefix) = pat.strip_suffix('*') {
-            name.starts_with(prefix)
-        } else {
-            name == pat
+        if !pat.contains('*') {
+            return name == pat;
         }
+        let parts: Vec<&str> = pat.split('*').collect();
+        // All parts empty means the pattern is only `*`s — matches everything.
+        if parts.iter().all(|p| p.is_empty()) {
+            return true;
+        }
+        let mut remaining = name;
+        for (i, part) in parts.iter().enumerate() {
+            if part.is_empty() {
+                continue;
+            }
+            if i == 0 {
+                // First segment must be a prefix
+                if !remaining.starts_with(part) {
+                    return false;
+                }
+                remaining = &remaining[part.len()..];
+            } else if i == parts.len() - 1 {
+                // Last segment must be a suffix
+                if !remaining.ends_with(part) {
+                    return false;
+                }
+                // No need to advance — this is the final check.
+            } else {
+                // Interior segment: find it anywhere in the remainder
+                match remaining.find(part) {
+                    Some(pos) => remaining = &remaining[pos + part.len()..],
+                    None => return false,
+                }
+            }
+        }
+        true
     })
 }
 
@@ -694,11 +748,32 @@ mod tests {
         assert!(is_eager_match("muninn__muninn_recall", &patterns));
         assert!(is_eager_match("muninn__muninn_recall_tree", &patterns));
         assert!(!is_eager_match("muninn__muninn_remember", &patterns));
+
+        // Server-scoped infix patterns built via build_eager_patterns
+        let server_patterns =
+            build_eager_patterns(&[("muninn".to_string(), vec!["*recall*".to_string()])]);
+        assert_eq!(server_patterns, vec!["muninn__*recall*"]);
+        assert!(is_eager_match("muninn__muninn_recall", &server_patterns));
+        assert!(is_eager_match(
+            "muninn__muninn_recall_tree",
+            &server_patterns
+        ));
+        assert!(!is_eager_match("muninn__muninn_remember", &server_patterns));
     }
 
     #[test]
     fn eager_match_wildcard_all() {
         let patterns = vec!["*".to_string()];
         assert!(is_eager_match("anything", &patterns));
+    }
+
+    #[test]
+    fn build_eager_patterns_prefixes_all() {
+        let servers = vec![(
+            "muninn".to_string(),
+            vec!["*recall*".to_string(), "remember".to_string()],
+        )];
+        let patterns = build_eager_patterns(&servers);
+        assert_eq!(patterns, vec!["muninn__*recall*", "muninn__remember"]);
     }
 }

--- a/src/tools/tool_search.rs
+++ b/src/tools/tool_search.rs
@@ -200,7 +200,7 @@ mod tests {
 
     async fn make_deferred_set(stubs: Vec<DeferredMcpToolStub>) -> DeferredMcpToolSet {
         let registry = Arc::new(McpRegistry::connect_all(&[]).await.unwrap());
-        DeferredMcpToolSet { stubs, registry }
+        DeferredMcpToolSet::from_stubs(stubs, registry)
     }
 
     fn make_stub(name: &str, desc: &str) -> DeferredMcpToolStub {

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -11,3 +11,4 @@ mod memory_restart;
 mod report_template_tool_test;
 mod telegram_attachment_fallback;
 mod telegram_finalize_draft;
+mod telegram_user_signal;

--- a/tests/integration/telegram_user_signal.rs
+++ b/tests/integration/telegram_user_signal.rs
@@ -90,16 +90,25 @@ fn signal_with_image_attachment() {
 
 #[test]
 fn signal_without_handler_passes_raw_text() {
-    let handler = "";
     let text = "Some channel message";
-    let content = if handler.is_empty() {
-        text.to_string()
-    } else {
-        format!("[handler:{handler}]\n{text}")
-    };
+    let content = build_content("", text);
 
     assert!(!content.starts_with("[handler:"));
     assert_eq!(content, "Some channel message");
+
+    // Also verify that a non-empty handler does produce the prefix.
+    let with_handler = build_content("trading_signal", text);
+    assert!(with_handler.starts_with("[handler:trading_signal]"));
+}
+
+/// Build message content the same way the production listen loop does:
+/// prepend the handler prefix only when the handler string is non-empty.
+fn build_content(handler: &str, text: &str) -> String {
+    if handler.is_empty() {
+        text.to_string()
+    } else {
+        format!("[handler:{handler}]\n{text}")
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -107,24 +116,28 @@ fn signal_without_handler_passes_raw_text() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[cfg(feature = "channel-telegram-user")]
-#[test]
-fn channel_construction_from_config() {
-    use hrafn::channels::telegram_user::TelegramUserChannel;
-    use hrafn::channels::traits::Channel;
+fn test_config(channel: &str, handler: &str) -> hrafn::config::TelegramUserConfig {
     use hrafn::config::{TelegramUserConfig, TelegramUserWatchConfig};
-
-    let config = TelegramUserConfig {
+    TelegramUserConfig {
         api_id: 12345,
         api_hash: "test_hash".to_string(),
         phone: "+1 555 0100".to_string(),
         session_file: "/tmp/test.session".to_string(),
         watch: vec![TelegramUserWatchConfig {
-            channel: "test_channel".to_string(),
-            handler: "trading_signal".to_string(),
+            channel: channel.to_string(),
+            handler: handler.to_string(),
         }],
         reply_via_bot: Some("@test_bot".to_string()),
-    };
+    }
+}
 
+#[cfg(feature = "channel-telegram-user")]
+#[test]
+fn channel_construction_from_config() {
+    use hrafn::channels::telegram_user::TelegramUserChannel;
+    use hrafn::channels::traits::Channel;
+
+    let config = test_config("test_channel", "trading_signal");
     let channel = TelegramUserChannel::new(&config);
     assert_eq!(channel.name(), "telegram_user");
 }
@@ -138,20 +151,8 @@ fn channel_construction_from_config() {
 async fn send_is_noop() {
     use hrafn::channels::telegram_user::TelegramUserChannel;
     use hrafn::channels::traits::{Channel, SendMessage};
-    use hrafn::config::{TelegramUserConfig, TelegramUserWatchConfig};
 
-    let config = TelegramUserConfig {
-        api_id: 12345,
-        api_hash: "test_hash".to_string(),
-        phone: "+1 555 0100".to_string(),
-        session_file: "/tmp/test.session".to_string(),
-        watch: vec![TelegramUserWatchConfig {
-            channel: "test".to_string(),
-            handler: "".to_string(),
-        }],
-        reply_via_bot: Some("@test_bot".to_string()),
-    };
-
+    let config = test_config("test", "");
     let channel = TelegramUserChannel::new(&config);
     let msg = SendMessage::new("hello", "@someone");
 
@@ -166,7 +167,7 @@ async fn send_is_noop() {
 
 #[test]
 fn multiple_watch_configs_produce_distinct_messages() {
-    let channels = vec![("channel_a", "handler_1"), ("channel_b", "handler_2")];
+    let channels = [("channel_a", "handler_1"), ("channel_b", "handler_2")];
 
     let messages: Vec<ChannelMessage> = channels
         .iter()

--- a/tests/integration/telegram_user_signal.rs
+++ b/tests/integration/telegram_user_signal.rs
@@ -1,0 +1,196 @@
+//! Integration tests for the telegram_user channel signal pipeline.
+//!
+//! Since we can't connect to real Telegram (needs credentials), these tests
+//! verify the testable contracts: message construction, handler prefix logic,
+//! ID uniqueness, attachment structure, and Channel trait behaviour.
+//!
+//! Issue: #164
+
+use hrafn::channels::media_pipeline::MediaAttachment;
+use hrafn::channels::traits::ChannelMessage;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 1: Handler prefix in signal content
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn channel_message_from_signal_has_handler_prefix() {
+    let msg = ChannelMessage {
+        id: "tgu_100eyes_12345".into(),
+        sender: "100eyes_crypto".into(),
+        reply_target: "@my_hrafn_bot".into(),
+        content: "[handler:trading_signal]\nBTCUSDT Long, TP 70000, SL 65000".into(),
+        channel: "telegram_user".into(),
+        timestamp: 1700000000,
+        thread_ts: None,
+        interruption_scope_id: None,
+        attachments: vec![],
+    };
+
+    assert!(msg.content.starts_with("[handler:trading_signal]"));
+    assert_eq!(msg.channel, "telegram_user");
+    assert_eq!(msg.sender, "100eyes_crypto");
+    // Reply target routes to bot, not back to the watched channel
+    assert_eq!(msg.reply_target, "@my_hrafn_bot");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 2: Message ID uniqueness per channel
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn signal_message_id_includes_channel_and_msg_id() {
+    let id1 = format!("tgu_{}_{}", "channel_a", 123);
+    let id2 = format!("tgu_{}_{}", "channel_b", 123);
+    let id3 = format!("tgu_{}_{}", "channel_a", 456);
+
+    assert_ne!(id1, id2, "different channels should produce different IDs");
+    assert_ne!(
+        id1, id3,
+        "different message IDs should produce different IDs"
+    );
+    assert!(id1.starts_with("tgu_"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 3: Image attachment structure
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn signal_with_image_attachment() {
+    let image_bytes = vec![0xFF, 0xD8, 0xFF, 0xE0]; // JPEG magic bytes
+    let attachment = MediaAttachment {
+        file_name: "signal_1700000000.jpg".to_string(),
+        data: image_bytes.clone(),
+        mime_type: Some("image/jpeg".to_string()),
+    };
+
+    let msg = ChannelMessage {
+        id: "tgu_100eyes_789".into(),
+        sender: "100eyes".into(),
+        reply_target: "@bot".into(),
+        content: "[handler:trading_signal]\nXRPUSDT Long".into(),
+        channel: "telegram_user".into(),
+        timestamp: 1700000000,
+        thread_ts: None,
+        interruption_scope_id: None,
+        attachments: vec![attachment],
+    };
+
+    assert_eq!(msg.attachments.len(), 1);
+    assert_eq!(msg.attachments[0].mime_type, Some("image/jpeg".to_string()));
+    assert!(msg.attachments[0].file_name.starts_with("signal_"));
+    assert!(msg.attachments[0].file_name.ends_with(".jpg"));
+    assert_eq!(msg.attachments[0].data, image_bytes);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 4: No handler prefix when handler is empty
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn signal_without_handler_passes_raw_text() {
+    let handler = "";
+    let text = "Some channel message";
+    let content = if handler.is_empty() {
+        text.to_string()
+    } else {
+        format!("[handler:{handler}]\n{text}")
+    };
+
+    assert!(!content.starts_with("[handler:"));
+    assert_eq!(content, "Some channel message");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 5: Channel construction from config (feature-gated)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "channel-telegram-user")]
+#[test]
+fn channel_construction_from_config() {
+    use hrafn::channels::telegram_user::TelegramUserChannel;
+    use hrafn::channels::traits::Channel;
+    use hrafn::config::{TelegramUserConfig, TelegramUserWatchConfig};
+
+    let config = TelegramUserConfig {
+        api_id: 12345,
+        api_hash: "test_hash".to_string(),
+        phone: "+1 555 0100".to_string(),
+        session_file: "/tmp/test.session".to_string(),
+        watch: vec![TelegramUserWatchConfig {
+            channel: "test_channel".to_string(),
+            handler: "trading_signal".to_string(),
+        }],
+        reply_via_bot: Some("@test_bot".to_string()),
+    };
+
+    let channel = TelegramUserChannel::new(&config);
+    assert_eq!(channel.name(), "telegram_user");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 6: send() is a no-op (feature-gated)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "channel-telegram-user")]
+#[tokio::test]
+async fn send_is_noop() {
+    use hrafn::channels::telegram_user::TelegramUserChannel;
+    use hrafn::channels::traits::{Channel, SendMessage};
+    use hrafn::config::{TelegramUserConfig, TelegramUserWatchConfig};
+
+    let config = TelegramUserConfig {
+        api_id: 12345,
+        api_hash: "test_hash".to_string(),
+        phone: "+1 555 0100".to_string(),
+        session_file: "/tmp/test.session".to_string(),
+        watch: vec![TelegramUserWatchConfig {
+            channel: "test".to_string(),
+            handler: "".to_string(),
+        }],
+        reply_via_bot: Some("@test_bot".to_string()),
+    };
+
+    let channel = TelegramUserChannel::new(&config);
+    let msg = SendMessage::new("hello", "@someone");
+
+    // send() should succeed (it's a no-op)
+    let result = channel.send(&msg).await;
+    assert!(result.is_ok());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 7: Multiple watch configs produce distinct messages
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn multiple_watch_configs_produce_distinct_messages() {
+    let channels = vec![("channel_a", "handler_1"), ("channel_b", "handler_2")];
+
+    let messages: Vec<ChannelMessage> = channels
+        .iter()
+        .enumerate()
+        .map(|(i, (ch, handler))| {
+            let text = format!("Signal from {ch}");
+            let content = format!("[handler:{handler}]\n{text}");
+            ChannelMessage {
+                id: format!("tgu_{}_{}", ch, i),
+                sender: ch.to_string(),
+                reply_target: "@bot".into(),
+                content,
+                channel: "telegram_user".into(),
+                timestamp: 1700000000 + i as u64,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+            }
+        })
+        .collect();
+
+    assert_eq!(messages.len(), 2);
+    assert_ne!(messages[0].id, messages[1].id);
+    assert_ne!(messages[0].sender, messages[1].sender);
+    assert!(messages[0].content.contains("[handler:handler_1]"));
+    assert!(messages[1].content.contains("[handler:handler_2]"));
+}


### PR DESCRIPTION
## Summary

- **BM25 ranking** replaces naive term-hit-counting in deferred tool search. Uses Okapi BM25 (k1=1.2, b=0.75) with precomputed corpus stats, making rare-term matches rank significantly higher than common-term matches.
- **Per-tool `eager_tools`** config on `McpServerConfig` — glob patterns (e.g. `"recall*"`, `"*shell*"`) for tools that should load eagerly even when `deferred_loading: true`. High-frequency tools skip the `tool_search` roundtrip.

## Motivation

Ref: https://vasudev.xyz/blog/mcp-context-window-fix/index.txt — Anthropic's deferred loading pattern recommends BM25 for tool discovery and per-tool granularity for frequently-used tools. Hrafn had the architecture but lacked both.

## Changes

| File | What |
|------|------|
| `src/tools/mcp_deferred.rs` | `BM25Index` struct, `is_eager_match()`, updated `from_registry()` |
| `src/config/schema.rs` | `eager_tools: Vec<String>` on `McpServerConfig` |
| `src/agent/agent.rs` | Wire eager patterns into deferred set construction |
| `src/agent/loop_.rs` | Same wiring for the loop-based agent path |
| `src/channels/mod.rs` | Same wiring for channel-driven sessions |
| `src/gateway/mod.rs` | Same wiring for HTTP gateway sessions |
| `src/tools/tool_search.rs` | Minor: use updated `from_stubs()` in tests |

## Config example

```toml
[mcp]
deferred_loading = true

[[mcp.servers]]
name = "muninn"
command = "muninndb-mcp"
eager_tools = ["recall", "remember*"]

[[mcp.servers]]
name = "filesystem"
command = "fs-mcp"
eager_tools = ["read_file", "write_file"]
```

## Test plan

- [x] `cargo test` — all 288 related tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] BM25 test: rare-term match ranks higher than common-term match
- [x] Eager glob tests: exact, prefix `*`, suffix `*`, wildcard `*`
- [ ] Manual: verify with a real MCP server that eager tools skip tool_search

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add eager_tools config to eagerly register selected MCP tools at startup (per-server patterns); logs report counts and warn when matches are missing
  * Tool search now uses BM25-based ranking for more relevant results

* **Tests**
  * New integration tests for Telegram user signal pipeline covering formatting, routing, attachments, and channel behavior

* **Documentation**
  * Document MCP config, eager_tools patterns, BM25 search, and updated troubleshooting guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->