### PR TITLE
Add MCP push notification receiver

### DIFF
--- a/src/channels/mcp_notification.rs
+++ b/src/channels/mcp_notification.rs
@@ -215,9 +215,7 @@ async fn run_sse_listener(
             );
         }
         Err(e) => {
-            tracing::warn!(
-                "MCP notification subscribe to `{server_name}` failed (non-fatal): {e}"
-            );
+            tracing::warn!("MCP notification subscribe to `{server_name}` failed (non-fatal): {e}");
         }
     }
 
@@ -250,8 +248,7 @@ async fn run_sse_listener(
 
                 match serde_json::from_str::<Value>(&data) {
                     Ok(msg) => {
-                        let method =
-                            msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+                        let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
 
                         if method == "notifications/alert_triggered" {
                             if let Some(channel_msg) =

--- a/src/channels/mcp_notification.rs
+++ b/src/channels/mcp_notification.rs
@@ -1,0 +1,405 @@
+//! MCP push notification bridge.
+//!
+//! Converts incoming `notifications/alert_triggered` JSON-RPC messages from an
+//! MCP server into [`ChannelMessage`] objects that feed into the agent loop.
+//! Also provides a standalone SSE listener that connects to an MCP server's
+//! SSE endpoint, parses notifications, and sends them to the channel message bus.
+
+use super::traits::ChannelMessage;
+use serde_json::Value;
+
+/// Convert an MCP alert notification into a ChannelMessage for the agent loop.
+pub fn alert_notification_to_channel_message(
+    notification: &Value,
+    reply_target: &str,
+) -> Option<ChannelMessage> {
+    let params = notification.get("params")?;
+    let alert_id = params.get("alert_id")?.as_str()?;
+    let symbol = params.get("symbol")?.as_str()?;
+    let triggered_at = params
+        .get("triggered_at")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let value = params.get("value").and_then(|v| v.as_f64()).unwrap_or(0.0);
+
+    let condition = params
+        .get("condition")
+        .cloned()
+        .unwrap_or(serde_json::json!({}));
+    let condition_type = condition
+        .get("type")
+        .and_then(|t| t.as_str())
+        .unwrap_or("unknown");
+
+    let condition_desc = match condition_type {
+        "price_above" => format!(
+            "Price above {}",
+            condition
+                .get("threshold")
+                .and_then(|t| t.as_f64())
+                .unwrap_or(0.0)
+        ),
+        "price_below" => format!(
+            "Price below {}",
+            condition
+                .get("threshold")
+                .and_then(|t| t.as_f64())
+                .unwrap_or(0.0)
+        ),
+        "indicator_signal" => {
+            let indicator = condition
+                .get("indicator")
+                .and_then(|i| i.as_str())
+                .unwrap_or("unknown");
+            let signal = condition
+                .get("signal")
+                .and_then(|s| s.as_str())
+                .unwrap_or("unknown");
+            format!("{indicator} {signal}")
+        }
+        _ => format!("{condition:?}"),
+    };
+
+    let content = format!(
+        "[handler:alert_response]\n\
+         Alert triggered: {alert_id} on {symbol}\n\
+         Condition: {condition_desc}\n\
+         Value: {value:.6}\n\
+         Time: {triggered_at}"
+    );
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    Some(ChannelMessage {
+        id: format!("alert_{alert_id}"),
+        sender: "chartgen".to_string(),
+        reply_target: reply_target.to_string(),
+        content,
+        channel: "mcp_notification".to_string(),
+        timestamp,
+        thread_ts: None,
+        interruption_scope_id: None,
+        attachments: vec![],
+    })
+}
+
+/// Spawn a background task that connects to an MCP server's SSE endpoint,
+/// subscribes to push notifications, and forwards `notifications/alert_triggered`
+/// messages into the channel message bus.
+///
+/// Reconnects with exponential backoff (1 s -> 60 s) on disconnect.
+#[allow(clippy::implicit_hasher)]
+pub fn spawn_notification_listener(
+    server_name: String,
+    sse_url: String,
+    headers: std::collections::HashMap<String, String>,
+    reply_target: String,
+    symbols: Vec<String>,
+    alert_types: Vec<String>,
+    tx: tokio::sync::mpsc::Sender<ChannelMessage>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut backoff_secs: u64 = 1;
+        const MAX_BACKOFF_SECS: u64 = 60;
+
+        loop {
+            tracing::info!("MCP notification listener connecting to `{server_name}` at {sse_url}");
+            match run_sse_listener(
+                &server_name,
+                &sse_url,
+                &headers,
+                &reply_target,
+                &symbols,
+                &alert_types,
+                &tx,
+            )
+            .await
+            {
+                Ok(()) => {
+                    tracing::info!(
+                        "MCP notification listener for `{server_name}` disconnected cleanly"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!("MCP notification listener for `{server_name}` error: {e:#}");
+                }
+            }
+            tracing::info!(
+                "MCP notification listener for `{server_name}` reconnecting in {backoff_secs}s"
+            );
+            tokio::time::sleep(tokio::time::Duration::from_secs(backoff_secs)).await;
+            backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF_SECS);
+        }
+    })
+}
+
+/// Connect to the SSE endpoint, subscribe, and process events until disconnect.
+async fn run_sse_listener(
+    server_name: &str,
+    sse_url: &str,
+    headers: &std::collections::HashMap<String, String>,
+    reply_target: &str,
+    symbols: &[String],
+    alert_types: &[String],
+    tx: &tokio::sync::mpsc::Sender<ChannelMessage>,
+) -> anyhow::Result<()> {
+    use tokio::io::AsyncBufReadExt;
+
+    let client = reqwest::Client::builder()
+        .build()
+        .map_err(|e| anyhow::anyhow!("failed to build HTTP client: {e}"))?;
+
+    let mut req = client
+        .get(sse_url)
+        .header("Accept", "text/event-stream")
+        .header("Cache-Control", "no-cache");
+    for (key, value) in headers {
+        req = req.header(key, value);
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("SSE connect to `{server_name}` failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        anyhow::bail!(
+            "SSE connect to `{server_name}` returned HTTP {}",
+            resp.status()
+        );
+    }
+
+    // After connecting, send subscribe_notifications as a POST to the same URL.
+    let mut subscribe_params = serde_json::Map::new();
+    if !symbols.is_empty() {
+        subscribe_params.insert("symbols".to_string(), serde_json::json!(symbols));
+    }
+    if !alert_types.is_empty() {
+        subscribe_params.insert("types".to_string(), serde_json::json!(alert_types));
+    }
+    let subscribe_req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "subscribe_notifications",
+        "params": subscribe_params,
+    });
+
+    let mut post_req = client
+        .post(sse_url)
+        .header("Content-Type", "application/json")
+        .json(&subscribe_req);
+    for (key, value) in headers {
+        post_req = post_req.header(key, value);
+    }
+    if let Err(e) = post_req.send().await {
+        tracing::warn!("MCP notification subscribe to `{server_name}` failed (non-fatal): {e}");
+    }
+
+    tracing::info!("MCP notification listener for `{server_name}` connected, reading events");
+
+    // Read SSE stream
+    let stream = resp
+        .bytes_stream()
+        .map(|item| item.map_err(std::io::Error::other));
+    let reader = tokio_util::io::StreamReader::new(stream);
+    let mut lines = tokio::io::BufReader::new(reader).lines();
+
+    let mut cur_data: Vec<String> = Vec::new();
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        let line = line.trim_end_matches('\r').to_string();
+
+        if line.is_empty() {
+            // End of event — process accumulated data
+            if !cur_data.is_empty() {
+                let data = cur_data.join("\n");
+                cur_data.clear();
+
+                if let Ok(msg) = serde_json::from_str::<Value>(&data) {
+                    let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+
+                    if method == "notifications/alert_triggered" {
+                        if let Some(channel_msg) =
+                            alert_notification_to_channel_message(&msg, reply_target)
+                        {
+                            tracing::info!(
+                                "MCP notification from `{server_name}`: alert {}",
+                                channel_msg.id
+                            );
+                            if tx.send(channel_msg).await.is_err() {
+                                tracing::warn!(
+                                    "MCP notification channel for `{server_name}` closed"
+                                );
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+            }
+            continue;
+        }
+
+        if let Some(data_line) = line.strip_prefix("data:") {
+            cur_data.push(data_line.trim_start().to_string());
+        }
+    }
+
+    Ok(())
+}
+
+use tokio_stream::StreamExt;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_notification(condition_type: &str) -> Value {
+        let condition = match condition_type {
+            "price_above" => json!({"type": "price_above", "threshold": 50000.0}),
+            "price_below" => json!({"type": "price_below", "threshold": 28000.0}),
+            "indicator_signal" => {
+                json!({"type": "indicator_signal", "indicator": "RSI", "signal": "oversold"})
+            }
+            _ => json!({"type": condition_type}),
+        };
+
+        json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/alert_triggered",
+            "params": {
+                "alert_id": "alert-001",
+                "symbol": "BTC/USDT",
+                "triggered_at": "2026-01-15T10:30:00Z",
+                "value": 49_999.123_456,
+                "condition": condition
+            }
+        })
+    }
+
+    #[test]
+    fn parse_valid_notification_produces_correct_fields() {
+        let notif = sample_notification("price_above");
+        let msg = alert_notification_to_channel_message(&notif, "chat_123").unwrap();
+
+        assert_eq!(msg.id, "alert_alert-001");
+        assert_eq!(msg.sender, "chartgen");
+        assert_eq!(msg.reply_target, "chat_123");
+        assert_eq!(msg.channel, "mcp_notification");
+        assert!(msg.content.contains("BTC/USDT"));
+        assert!(msg.content.contains("alert-001"));
+        assert!(msg.content.contains("49999.123456"));
+        assert!(msg.content.contains("2026-01-15T10:30:00Z"));
+    }
+
+    #[test]
+    fn handler_tag_present_in_content() {
+        let notif = sample_notification("price_above");
+        let msg = alert_notification_to_channel_message(&notif, "").unwrap();
+
+        assert!(msg.content.starts_with("[handler:alert_response]"));
+    }
+
+    #[test]
+    fn missing_params_returns_none() {
+        let notif = json!({"jsonrpc": "2.0", "method": "notifications/alert_triggered"});
+        assert!(alert_notification_to_channel_message(&notif, "").is_none());
+    }
+
+    #[test]
+    fn missing_alert_id_returns_none() {
+        let notif = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/alert_triggered",
+            "params": {
+                "symbol": "BTC/USDT"
+            }
+        });
+        assert!(alert_notification_to_channel_message(&notif, "").is_none());
+    }
+
+    #[test]
+    fn missing_symbol_returns_none() {
+        let notif = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/alert_triggered",
+            "params": {
+                "alert_id": "a1"
+            }
+        });
+        assert!(alert_notification_to_channel_message(&notif, "").is_none());
+    }
+
+    #[test]
+    fn price_above_condition_formatted() {
+        let notif = sample_notification("price_above");
+        let msg = alert_notification_to_channel_message(&notif, "").unwrap();
+        assert!(msg.content.contains("Price above 50000"));
+    }
+
+    #[test]
+    fn price_below_condition_formatted() {
+        let notif = sample_notification("price_below");
+        let msg = alert_notification_to_channel_message(&notif, "").unwrap();
+        assert!(msg.content.contains("Price below 28000"));
+    }
+
+    #[test]
+    fn indicator_signal_condition_formatted() {
+        let notif = sample_notification("indicator_signal");
+        let msg = alert_notification_to_channel_message(&notif, "").unwrap();
+        assert!(msg.content.contains("RSI oversold"));
+    }
+
+    #[test]
+    fn unknown_condition_type_uses_debug_format() {
+        let notif = sample_notification("custom_type");
+        let msg = alert_notification_to_channel_message(&notif, "").unwrap();
+        // Should contain the debug representation of the condition JSON
+        assert!(msg.content.contains("custom_type"));
+    }
+
+    #[test]
+    fn reply_target_passed_through() {
+        let notif = sample_notification("price_above");
+        let msg = alert_notification_to_channel_message(&notif, "telegram:12345").unwrap();
+        assert_eq!(msg.reply_target, "telegram:12345");
+    }
+
+    #[test]
+    fn empty_reply_target_is_valid() {
+        let notif = sample_notification("price_above");
+        let msg = alert_notification_to_channel_message(&notif, "").unwrap();
+        assert_eq!(msg.reply_target, "");
+    }
+
+    #[test]
+    fn missing_triggered_at_defaults_to_unknown() {
+        let notif = json!({
+            "params": {
+                "alert_id": "a1",
+                "symbol": "ETH/USDT",
+                "value": 1.0,
+                "condition": {"type": "price_above", "threshold": 3000.0}
+            }
+        });
+        let msg = alert_notification_to_channel_message(&notif, "").unwrap();
+        assert!(msg.content.contains("Time: unknown"));
+    }
+
+    #[test]
+    fn missing_value_defaults_to_zero() {
+        let notif = json!({
+            "params": {
+                "alert_id": "a1",
+                "symbol": "ETH/USDT",
+                "triggered_at": "2026-01-01T00:00:00Z",
+                "condition": {"type": "price_above", "threshold": 3000.0}
+            }
+        });
+        let msg = alert_notification_to_channel_message(&notif, "").unwrap();
+        assert!(msg.content.contains("Value: 0.000000"));
+    }
+}

--- a/src/channels/mcp_notification.rs
+++ b/src/channels/mcp_notification.rs
@@ -106,7 +106,14 @@ pub fn spawn_notification_listener(
         const MAX_BACKOFF_SECS: u64 = 60;
 
         loop {
-            tracing::info!("MCP notification listener connecting to `{server_name}` at {sse_url}");
+            if tx.is_closed() {
+                tracing::info!(
+                    "MCP notification listener for `{server_name}` stopping: channel closed"
+                );
+                break;
+            }
+            tracing::info!("MCP notification listener connecting to `{server_name}`");
+            tracing::debug!("MCP notification listener `{server_name}` endpoint: {sse_url}");
             match run_sse_listener(
                 &server_name,
                 &sse_url,
@@ -126,6 +133,12 @@ pub fn spawn_notification_listener(
                 Err(e) => {
                     tracing::warn!("MCP notification listener for `{server_name}` error: {e:#}");
                 }
+            }
+            if tx.is_closed() {
+                tracing::info!(
+                    "MCP notification listener for `{server_name}` stopping: channel closed"
+                );
+                break;
             }
             tracing::info!(
                 "MCP notification listener for `{server_name}` reconnecting in {backoff_secs}s"
@@ -193,8 +206,19 @@ async fn run_sse_listener(
     for (key, value) in headers {
         post_req = post_req.header(key, value);
     }
-    if let Err(e) = post_req.send().await {
-        tracing::warn!("MCP notification subscribe to `{server_name}` failed (non-fatal): {e}");
+    match post_req.send().await {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => {
+            tracing::warn!(
+                "MCP notification subscribe to `{server_name}` returned HTTP {} (non-fatal)",
+                resp.status()
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                "MCP notification subscribe to `{server_name}` failed (non-fatal): {e}"
+            );
+        }
     }
 
     tracing::info!("MCP notification listener for `{server_name}` connected, reading events");
@@ -217,24 +241,32 @@ async fn run_sse_listener(
                 let data = cur_data.join("\n");
                 cur_data.clear();
 
-                if let Ok(msg) = serde_json::from_str::<Value>(&data) {
-                    let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+                match serde_json::from_str::<Value>(&data) {
+                    Ok(msg) => {
+                        let method =
+                            msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
 
-                    if method == "notifications/alert_triggered" {
-                        if let Some(channel_msg) =
-                            alert_notification_to_channel_message(&msg, reply_target)
-                        {
-                            tracing::info!(
-                                "MCP notification from `{server_name}`: alert {}",
-                                channel_msg.id
-                            );
-                            if tx.send(channel_msg).await.is_err() {
-                                tracing::warn!(
-                                    "MCP notification channel for `{server_name}` closed"
+                        if method == "notifications/alert_triggered" {
+                            if let Some(channel_msg) =
+                                alert_notification_to_channel_message(&msg, reply_target)
+                            {
+                                tracing::info!(
+                                    "MCP notification from `{server_name}`: alert {}",
+                                    channel_msg.id
                                 );
-                                return Ok(());
+                                if tx.send(channel_msg).await.is_err() {
+                                    tracing::warn!(
+                                        "MCP notification channel for `{server_name}` closed"
+                                    );
+                                    return Ok(());
+                                }
                             }
                         }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "MCP notification from `{server_name}` had invalid JSON: {e}"
+                        );
                     }
                 }
             }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -34,6 +34,7 @@ pub mod linq;
 #[cfg(feature = "channel-matrix")]
 pub mod matrix;
 pub mod mattermost;
+pub mod mcp_notification;
 pub mod media_pipeline;
 pub mod mochat;
 pub mod mqtt;
@@ -5482,6 +5483,35 @@ pub async fn start_channels(config: Config) -> Result<()> {
             max_backoff_secs,
         ));
     }
+    // Spawn MCP notification listeners for servers with subscribe_notifications enabled.
+    if config.mcp.enabled {
+        for server_cfg in &config.mcp.servers {
+            if !server_cfg.subscribe_notifications {
+                continue;
+            }
+            let Some(ref url) = server_cfg.url else {
+                tracing::warn!(
+                    "MCP server `{}` has subscribe_notifications but no URL — skipping",
+                    server_cfg.name
+                );
+                continue;
+            };
+            tracing::info!(
+                "Spawning MCP notification listener for `{}`",
+                server_cfg.name
+            );
+            handles.push(mcp_notification::spawn_notification_listener(
+                server_cfg.name.clone(),
+                url.clone(),
+                server_cfg.headers.clone(),
+                server_cfg.notification_reply_target.clone(),
+                server_cfg.notification_symbols.clone(),
+                server_cfg.notification_types.clone(),
+                tx.clone(),
+            ));
+        }
+    }
+
     drop(tx); // Drop our copy so rx closes when all channels stop
 
     let channels_by_name = Arc::new(

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -948,6 +948,19 @@ pub struct McpServerConfig {
     /// Optional per-call timeout in seconds (hard capped in validation).
     #[serde(default)]
     pub tool_timeout_secs: Option<u64>,
+    /// Subscribe to push notifications on connect.
+    #[serde(default)]
+    pub subscribe_notifications: bool,
+    /// Filter notifications by symbols (empty = all).
+    #[serde(default)]
+    pub notification_symbols: Vec<String>,
+    /// Filter notifications by alert types (empty = all).
+    #[serde(default)]
+    pub notification_types: Vec<String>,
+    /// Reply target for notification-generated messages (e.g. a Telegram chat ID).
+    /// Falls back to empty string if not set.
+    #[serde(default)]
+    pub notification_reply_target: String,
 }
 
 /// External MCP client configuration (`[mcp]` section).
@@ -16043,6 +16056,50 @@ require_otp_to_resume = true
         let cfg = McpConfig::default();
         assert!(!cfg.enabled);
         assert!(cfg.servers.is_empty());
+    }
+
+    #[test]
+    async fn mcp_server_config_notification_fields_default_correctly() {
+        let cfg = McpServerConfig::default();
+        assert!(!cfg.subscribe_notifications);
+        assert!(cfg.notification_symbols.is_empty());
+        assert!(cfg.notification_types.is_empty());
+        assert!(cfg.notification_reply_target.is_empty());
+    }
+
+    #[test]
+    async fn mcp_server_config_notification_fields_deserialize() {
+        let json = r#"{
+            "name": "charts",
+            "transport": "sse",
+            "url": "https://example.com/mcp",
+            "subscribe_notifications": true,
+            "notification_symbols": ["BTC/USDT", "ETH/USDT"],
+            "notification_types": ["price_above", "indicator_signal"],
+            "notification_reply_target": "telegram:12345"
+        }"#;
+        let cfg: McpServerConfig = serde_json::from_str(json).expect("deserialize");
+        assert!(cfg.subscribe_notifications);
+        assert_eq!(cfg.notification_symbols, vec!["BTC/USDT", "ETH/USDT"]);
+        assert_eq!(
+            cfg.notification_types,
+            vec!["price_above", "indicator_signal"]
+        );
+        assert_eq!(cfg.notification_reply_target, "telegram:12345");
+    }
+
+    #[test]
+    async fn mcp_server_config_without_notification_fields_deserializes() {
+        let json = r#"{
+            "name": "fs",
+            "transport": "stdio",
+            "command": "/usr/bin/mcp-fs"
+        }"#;
+        let cfg: McpServerConfig = serde_json::from_str(json).expect("deserialize");
+        assert!(!cfg.subscribe_notifications);
+        assert!(cfg.notification_symbols.is_empty());
+        assert!(cfg.notification_types.is_empty());
+        assert!(cfg.notification_reply_target.is_empty());
     }
 
     #[test]

--- a/src/tools/mcp_client.rs
+++ b/src/tools/mcp_client.rs
@@ -310,12 +310,8 @@ mod tests {
         let config = McpServerConfig {
             name: "nonexistent".to_string(),
             command: "/usr/bin/this_binary_does_not_exist_hrafn_test".to_string(),
-            args: vec![],
-            env: std::collections::HashMap::default(),
-            tool_timeout_secs: None,
             transport: McpTransport::Stdio,
-            url: None,
-            headers: std::collections::HashMap::default(),
+            ..Default::default()
         };
         let result = McpServer::connect(config).await;
         assert!(result.is_err());
@@ -329,12 +325,8 @@ mod tests {
         let configs = vec![McpServerConfig {
             name: "bad".to_string(),
             command: "/usr/bin/does_not_exist_zc_test".to_string(),
-            args: vec![],
-            env: std::collections::HashMap::default(),
-            tool_timeout_secs: None,
             transport: McpTransport::Stdio,
-            url: None,
-            headers: std::collections::HashMap::default(),
+            ..Default::default()
         }];
         let registry = McpRegistry::connect_all(&configs)
             .await

--- a/templates/alert_response.md
+++ b/templates/alert_response.md
@@ -1,0 +1,27 @@
+# Alert Response
+
+You received an automated alert from the trading engine.
+
+## Available MCP Tools
+
+- `charts__generate_chart` — generate a candlestick chart for a symbol/timeframe
+- `charts__get_indicators` — fetch indicator values for a symbol
+
+## Analysis Workflow
+
+1. **Review the alert**: Understand which condition triggered and at what value.
+2. **Run indicators**: Call `charts__get_indicators` to fetch current RSI, ADX, and
+   Cipher B status for the pair and timeframe.
+3. **Generate chart**: Call `charts__generate_chart` to produce a visual chart.
+   Send this chart to the user.
+4. **Evaluate**: Based on the triggered condition and current indicator readings,
+   determine if action is needed.
+5. **Decision**: Recommend one of:
+   - `place_order` — conditions confirm a trade setup
+   - `set_alert` — set a follow-up alert for further confirmation
+   - `skip` — conditions don't warrant action
+6. **Report**: Always explain the reasoning and send the chart to the user.
+
+## Language
+
+Respond in the same language the user writes in.

--- a/templates/alert_response.md
+++ b/templates/alert_response.md
@@ -21,6 +21,9 @@ You received an automated alert from the trading engine.
    - `set_alert` — set a follow-up alert for further confirmation
    - `skip` — conditions don't warrant action
 6. **Report**: Always explain the reasoning and send the chart to the user.
+7. **Failure fallback**: If tool calls fail (server unreachable, timeout), send a
+   plaintext summary to the user instead: alert condition, current value, and
+   recommended action. Do not block delivery waiting for a chart.
 
 ## Language
 


### PR DESCRIPTION
## Summary

- **Config (#173)**: Add optional notification subscription fields to `McpServerConfig` (`subscribe_notifications`, `notification_symbols`, `notification_types`, `notification_reply_target`) with serde defaults so existing configs are unaffected.
- **Bridge + template (#172)**: New `src/channels/mcp_notification.rs` converts `notifications/alert_triggered` JSON-RPC messages into `ChannelMessage` objects with `[handler:alert_response]` tag. New `templates/alert_response.md` provides the agent prompt for alert analysis.
- **SSE listener (#171)**: `spawn_notification_listener()` connects to an MCP server's SSE endpoint, subscribes to push notifications, parses incoming alerts, and feeds them into the channel message bus. Reconnects with exponential backoff (1s -> 60s).
- **Test cleanup**: Updated `mcp_client.rs` tests to use `..Default::default()` instead of enumerating all struct fields.

## Test plan

- [x] 13 unit tests for `mcp_notification`: valid parse, handler tag, missing params/fields, condition formatting (price_above, price_below, indicator_signal, unknown), reply target passthrough
- [x] 3 config tests: default values, deserialization with notification fields, deserialization without notification fields (backward compat)
- [x] All 119 existing MCP tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

Closes #171, closes #172, closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time MCP push notifications: subscribe to server alerts, convert them into app messages with human-readable summaries, and spawn per-server listeners with URL validation.
  * Per-server subscription settings: configure symbols, alert types, and a reply target for delivered alerts.
  * Automatic reconnect with exponential backoff for notification listeners.

* **Documentation**
  * Added an alert response template guiding analysis, chart generation, and follow-up actions.

* **Tests**
  * Unit tests for config defaults/deserialization and alert-to-message formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->