### PR TITLE
feat(tui): add Ratatui terminal UI with streaming output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,10 +1133,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cbc"
@@ -1433,6 +1448,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,7 +1495,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1882,6 +1911,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -2675,7 +2729,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_plain",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
 ]
 
@@ -2699,7 +2753,7 @@ dependencies = [
  "object 0.38.1",
  "serde",
  "sha2",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
 ]
 
@@ -3741,6 +3795,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
  "serde",
 ]
@@ -3923,6 +3979,7 @@ dependencies = [
  "cpal",
  "criterion",
  "cron",
+ "crossterm",
  "dialoguer",
  "directories",
  "extism",
@@ -3944,7 +4001,7 @@ dependencies = [
  "landlock",
  "lettre",
  "libc",
- "lru",
+ "lru 0.16.3",
  "mail-parser",
  "matrix-sdk",
  "mime_guess",
@@ -3962,6 +4019,7 @@ dependencies = [
  "prost 0.14.3",
  "qrcode",
  "rand 0.10.0",
+ "ratatui",
  "rcgen",
  "regex",
  "reqwest 0.12.28",
@@ -3996,6 +4054,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tui-textarea",
  "urlencoding",
  "uuid",
  "wa-rs",
@@ -4565,9 +4624,18 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -4587,6 +4655,19 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5176,6 +5257,15 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "weezl",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -6044,7 +6134,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
 dependencies = [
- "lru",
+ "lru 0.16.3",
  "nostr",
  "tokio",
 ]
@@ -6068,7 +6158,7 @@ dependencies = [
  "async-wsocket",
  "atomic-destructor",
  "hex",
- "lru",
+ "lru 0.16.3",
  "negentropy",
  "nostr",
  "nostr-database",
@@ -6715,6 +6805,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -7795,6 +7891,27 @@ name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru 0.12.5",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -9052,6 +9169,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9203,6 +9331,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stop-token"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9282,11 +9416,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10387,6 +10543,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10625,6 +10792,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10632,9 +10810,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -11634,7 +11812,7 @@ dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "wasm-encoder 0.246.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,11 @@ cpal = { version = "0.15", optional = true }
 # Terminal QR rendering for WhatsApp Web pairing flow.
 qrcode = { version = "0.14", optional = true }
 
+# TUI interface (ratatui + crossterm + tui-textarea)
+ratatui = { version = "0.29", optional = true, default-features = false, features = ["crossterm"] }
+crossterm = { version = "0.28", optional = true }
+tui-textarea = { version = "0.7", optional = true, default-features = false, features = ["crossterm"] }
+
 # WhatsApp Web client (wa-rs) — optional, enable with --features whatsapp-web
 # Uses wa-rs for Bot and Client, wa-rs-core for storage traits, custom rusqlite backend avoids Diesel conflict.
 wa-rs = { version = "0.2", optional = true, default-features = false }
@@ -343,6 +348,8 @@ voice-wake = ["dep:cpal"]
 plugins-wasm = ["dep:extism"]
 # WebAuthn / FIDO2 hardware key authentication
 webauthn = []
+# Terminal UI (ratatui-based interactive TUI)
+tui = ["dep:ratatui", "dep:crossterm", "dep:tui-textarea"]
 # Meta-feature for CI: all features except those requiring system C libraries
 # not available on standard CI runners (e.g., voice-wake needs libasound2-dev).
 ci-all = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,9 @@ pub mod verifiable_intent;
 #[cfg(feature = "plugins-wasm")]
 pub mod plugins;
 
+#[cfg(feature = "tui")]
+pub mod tui;
+
 #[cfg(feature = "desktop")]
 pub use config::Config;
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,234 @@
+pub mod theme;
+pub mod widgets;
+
+use std::io;
+
+use crossterm::{
+    ExecutableCommand,
+    event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
+    terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    Frame, Terminal,
+    layout::{Constraint, Direction, Layout, Rect},
+    widgets::{Block, Borders},
+};
+use tokio::{sync::mpsc, task::JoinHandle};
+use tui_textarea::TextArea;
+
+use widgets::SpinnerState;
+
+/// Sentinel string sent on the user-input channel to signal cancellation.
+pub const CANCEL_SENTINEL: &str = "__CANCEL__";
+
+pub struct App {
+    output: Vec<String>,
+    scroll_offset: u16,
+    auto_scroll: bool,
+    spinner: Option<SpinnerState>,
+    textarea: TextArea<'static>,
+    should_quit: bool,
+    tick: usize,
+}
+
+impl App {
+    fn new() -> Self {
+        let mut textarea = TextArea::default();
+        textarea.set_block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme::border()),
+        );
+        textarea.set_style(theme::style());
+        textarea.set_cursor_line_style(theme::style());
+        textarea.set_placeholder_text("> ");
+        textarea.set_placeholder_style(theme::dim());
+
+        Self {
+            output: Vec::new(),
+            scroll_offset: 0,
+            auto_scroll: true,
+            spinner: None,
+            textarea,
+            should_quit: false,
+            tick: 0,
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(self.layout_constraints())
+            .split(frame.area());
+
+        // Output pane
+        widgets::render_output_pane(frame, chunks[0], &self.output, self.scroll_offset);
+
+        // Spinner line (only when agent is processing)
+        if let Some(ref state) = self.spinner {
+            widgets::render_spinner_line(frame, chunks[1], state, self.tick);
+        }
+
+        // Input box
+        let input_idx = if self.spinner.is_some() { 2 } else { 1 };
+        frame.render_widget(&self.textarea, chunks[input_idx]);
+    }
+
+    fn layout_constraints(&self) -> Vec<Constraint> {
+        if self.spinner.is_some() {
+            vec![
+                Constraint::Min(3),
+                Constraint::Length(1),
+                Constraint::Length(3),
+            ]
+        } else {
+            vec![Constraint::Min(3), Constraint::Length(3)]
+        }
+    }
+
+    fn handle_submit(&mut self, tx: &mpsc::Sender<String>) {
+        let lines: Vec<String> = self.textarea.lines().to_vec();
+        let text = lines.join("\n").trim().to_string();
+        self.textarea.select_all();
+        self.textarea.cut();
+
+        if text.is_empty() {
+            return;
+        }
+
+        match text.as_str() {
+            "/quit" => {
+                self.should_quit = true;
+            }
+            "/clear" => {
+                self.output.clear();
+                self.scroll_offset = 0;
+            }
+            "/help" => {
+                self.push_output("Commands:".into());
+                self.push_output("  /quit   - Exit the TUI".into());
+                self.push_output("  /clear  - Clear output".into());
+                self.push_output("  /help   - Show this help".into());
+                self.push_output("  ESC     - Cancel in-progress request".into());
+                self.push_output("  Shift+Enter - Insert newline".into());
+            }
+            _ => {
+                self.push_output(format!("> {text}"));
+                self.spinner = Some(SpinnerState::new("pondering"));
+                // Non-blocking send; if the channel is full we drop the message
+                let _ = tx.try_send(text);
+            }
+        }
+    }
+
+    fn push_output(&mut self, line: String) {
+        self.output.push(line);
+        if self.auto_scroll {
+            self.scroll_to_bottom();
+        }
+    }
+
+    fn scroll_to_bottom(&mut self) {
+        let total = u16::try_from(self.output.len()).unwrap_or(u16::MAX);
+        self.scroll_offset = total.saturating_sub(1);
+    }
+
+    fn visible_output_height(&self, area: Rect) -> u16 {
+        // Output pane takes Min(3) so at least 3, minus 2 for borders
+        area.height
+            .saturating_sub(if self.spinner.is_some() { 4 } else { 3 })
+            .saturating_sub(2)
+    }
+}
+
+/// Spawn the TUI event loop on a tokio blocking task.
+///
+/// - `tx`: channel for sending user input (and cancel signals) to the agent.
+/// - `rx`: channel for receiving agent output lines.
+///
+/// Returns a `JoinHandle` that resolves when the TUI exits.
+pub fn spawn_tui(tx: mpsc::Sender<String>, mut rx: mpsc::Receiver<String>) -> JoinHandle<()> {
+    tokio::task::spawn_blocking(move || {
+        if let Err(e) = run_tui(tx, &mut rx) {
+            eprintln!("TUI error: {e}");
+        }
+    })
+}
+
+fn run_tui(tx: mpsc::Sender<String>, rx: &mut mpsc::Receiver<String>) -> io::Result<()> {
+    // Setup terminal
+    terminal::enable_raw_mode()?;
+    io::stdout().execute(EnterAlternateScreen)?;
+    let backend = ratatui::backend::CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app = App::new();
+
+    loop {
+        terminal.draw(|f| app.draw(f))?;
+
+        // Poll for crossterm events with a 100ms timeout (tick rate)
+        if event::poll(std::time::Duration::from_millis(100))? {
+            if let Event::Key(key) = event::read()? {
+                if handle_key_event(&mut app, &tx, key) {
+                    break;
+                }
+            }
+        }
+
+        // Drain incoming agent output (non-blocking)
+        while let Ok(line) = rx.try_recv() {
+            app.spinner = None;
+            app.push_output(line);
+        }
+
+        app.tick = app.tick.wrapping_add(1);
+
+        if app.should_quit {
+            break;
+        }
+    }
+
+    // Restore terminal
+    terminal::disable_raw_mode()?;
+    io::stdout().execute(LeaveAlternateScreen)?;
+    Ok(())
+}
+
+/// Returns `true` if the app should quit immediately.
+fn handle_key_event(app: &mut App, tx: &mpsc::Sender<String>, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Enter if !key.modifiers.contains(KeyModifiers::SHIFT) => {
+            app.handle_submit(tx);
+            false
+        }
+        KeyCode::Esc => {
+            if app.spinner.is_some() {
+                app.spinner = None;
+                let _ = tx.try_send(CANCEL_SENTINEL.to_string());
+                app.push_output("[cancelled]".into());
+            }
+            false
+        }
+        KeyCode::PageUp => {
+            app.auto_scroll = false;
+            app.scroll_offset = app.scroll_offset.saturating_sub(10);
+            false
+        }
+        KeyCode::PageDown => {
+            app.scroll_offset = app.scroll_offset.saturating_add(10);
+            // Re-enable auto-scroll if we're near the bottom
+            let total = u16::try_from(app.output.len()).unwrap_or(u16::MAX);
+            if app.scroll_offset >= total.saturating_sub(1) {
+                app.scroll_offset = total.saturating_sub(1);
+                app.auto_scroll = true;
+            }
+            false
+        }
+        _ => {
+            // Let tui-textarea handle the key event
+            app.textarea.input(key);
+            false
+        }
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -10,7 +10,7 @@ use crossterm::{
 };
 use ratatui::{
     Frame, Terminal,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout},
     widgets::{Block, Borders},
 };
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -132,13 +132,6 @@ impl App {
         let total = u16::try_from(self.output.len()).unwrap_or(u16::MAX);
         self.scroll_offset = total.saturating_sub(1);
     }
-
-    fn visible_output_height(&self, area: Rect) -> u16 {
-        // Output pane takes Min(3) so at least 3, minus 2 for borders
-        area.height
-            .saturating_sub(if self.spinner.is_some() { 4 } else { 3 })
-            .saturating_sub(2)
-    }
 }
 
 /// Spawn the TUI event loop on a tokio blocking task.
@@ -155,10 +148,21 @@ pub fn spawn_tui(tx: mpsc::Sender<String>, mut rx: mpsc::Receiver<String>) -> Jo
     })
 }
 
+/// Guard that restores terminal state on drop (including panics).
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+        let _ = io::stdout().execute(LeaveAlternateScreen);
+    }
+}
+
 fn run_tui(tx: mpsc::Sender<String>, rx: &mut mpsc::Receiver<String>) -> io::Result<()> {
-    // Setup terminal
     terminal::enable_raw_mode()?;
     io::stdout().execute(EnterAlternateScreen)?;
+    let _guard = TerminalGuard;
+
     let backend = ratatui::backend::CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
 
@@ -189,9 +193,6 @@ fn run_tui(tx: mpsc::Sender<String>, rx: &mut mpsc::Receiver<String>) -> io::Res
         }
     }
 
-    // Restore terminal
-    terminal::disable_raw_mode()?;
-    io::stdout().execute(LeaveAlternateScreen)?;
     Ok(())
 }
 

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,0 +1,20 @@
+use ratatui::style::{Color, Modifier, Style};
+
+pub const PRIMARY: Color = Color::Rgb(0, 255, 70);
+pub const BG: Color = Color::Reset;
+
+pub const fn style() -> Style {
+    Style::new().fg(PRIMARY).bg(BG)
+}
+
+pub const fn bold() -> Style {
+    style().add_modifier(Modifier::BOLD)
+}
+
+pub const fn border() -> Style {
+    Style::new().fg(PRIMARY)
+}
+
+pub const fn dim() -> Style {
+    Style::new().fg(PRIMARY).add_modifier(Modifier::DIM)
+}

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -11,41 +11,41 @@ use super::theme;
 
 const SPINNER_FRAMES: &[&str] = &["\u{25DC}", "\u{25DD}", "\u{25DE}", "\u{25DF}"];
 
-pub struct Spinner {
-    pub frames: &'static [&'static str],
+pub(crate) struct Spinner {
+    frames: &'static [&'static str],
 }
 
 impl Spinner {
-    pub fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             frames: SPINNER_FRAMES,
         }
     }
 
-    pub fn frame(&self, tick: usize) -> &'static str {
+    pub(crate) fn frame(&self, tick: usize) -> &'static str {
         self.frames[tick % self.frames.len()]
     }
 }
 
-pub struct SpinnerState {
-    pub start: Instant,
-    pub label: String,
+pub(crate) struct SpinnerState {
+    start: Instant,
+    pub(crate) label: String,
 }
 
 impl SpinnerState {
-    pub fn new(label: impl Into<String>) -> Self {
+    pub(crate) fn new(label: impl Into<String>) -> Self {
         Self {
             start: Instant::now(),
             label: label.into(),
         }
     }
 
-    pub fn elapsed_secs(&self) -> f64 {
+    pub(crate) fn elapsed_secs(&self) -> f64 {
         self.start.elapsed().as_secs_f64()
     }
 }
 
-pub fn render_output_pane(frame: &mut Frame, area: Rect, output: &[String], scroll_offset: u16) {
+pub(crate) fn render_output_pane(frame: &mut Frame, area: Rect, output: &[String], scroll_offset: u16) {
     let block = Block::default()
         .title(" Hrafn ")
         .title_style(theme::bold())
@@ -66,7 +66,7 @@ pub fn render_output_pane(frame: &mut Frame, area: Rect, output: &[String], scro
     frame.render_widget(paragraph, area);
 }
 
-pub fn render_spinner_line(frame: &mut Frame, area: Rect, state: &SpinnerState, tick: usize) {
+pub(crate) fn render_spinner_line(frame: &mut Frame, area: Rect, state: &SpinnerState, tick: usize) {
     let spinner = Spinner::new();
     let elapsed = state.elapsed_secs();
     let text = format!(

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -1,0 +1,82 @@
+use std::time::Instant;
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+
+use super::theme;
+
+const SPINNER_FRAMES: &[&str] = &["\u{25DC}", "\u{25DD}", "\u{25DE}", "\u{25DF}"];
+
+pub struct Spinner {
+    pub frames: &'static [&'static str],
+}
+
+impl Spinner {
+    pub fn new() -> Self {
+        Self {
+            frames: SPINNER_FRAMES,
+        }
+    }
+
+    pub fn frame(&self, tick: usize) -> &'static str {
+        self.frames[tick % self.frames.len()]
+    }
+}
+
+pub struct SpinnerState {
+    pub start: Instant,
+    pub label: String,
+}
+
+impl SpinnerState {
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            start: Instant::now(),
+            label: label.into(),
+        }
+    }
+
+    pub fn elapsed_secs(&self) -> f64 {
+        self.start.elapsed().as_secs_f64()
+    }
+}
+
+pub fn render_output_pane(frame: &mut Frame, area: Rect, output: &[String], scroll_offset: u16) {
+    let block = Block::default()
+        .title(" Hrafn ")
+        .title_style(theme::bold())
+        .borders(Borders::ALL)
+        .border_style(theme::border());
+
+    let lines: Vec<Line> = output
+        .iter()
+        .map(|s| Line::from(s.as_str()).style(theme::style()))
+        .collect();
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .scroll((scroll_offset, 0))
+        .style(theme::style());
+
+    frame.render_widget(paragraph, area);
+}
+
+pub fn render_spinner_line(frame: &mut Frame, area: Rect, state: &SpinnerState, tick: usize) {
+    let spinner = Spinner::new();
+    let elapsed = state.elapsed_secs();
+    let text = format!(
+        "{} {}... ({:.1}s)",
+        spinner.frame(tick),
+        state.label,
+        elapsed
+    );
+
+    let line = Line::from(vec![Span::styled(text, theme::dim())]);
+    let paragraph = Paragraph::new(line);
+    frame.render_widget(paragraph, area);
+}

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -45,7 +45,12 @@ impl SpinnerState {
     }
 }
 
-pub(crate) fn render_output_pane(frame: &mut Frame, area: Rect, output: &[String], scroll_offset: u16) {
+pub(crate) fn render_output_pane(
+    frame: &mut Frame,
+    area: Rect,
+    output: &[String],
+    scroll_offset: u16,
+) {
     let block = Block::default()
         .title(" Hrafn ")
         .title_style(theme::bold())
@@ -66,7 +71,12 @@ pub(crate) fn render_output_pane(frame: &mut Frame, area: Rect, output: &[String
     frame.render_widget(paragraph, area);
 }
 
-pub(crate) fn render_spinner_line(frame: &mut Frame, area: Rect, state: &SpinnerState, tick: usize) {
+pub(crate) fn render_spinner_line(
+    frame: &mut Frame,
+    area: Rect,
+    state: &SpinnerState,
+    tick: usize,
+) {
     let spinner = Spinner::new();
     let elapsed = state.elapsed_secs();
     let text = format!(


### PR DESCRIPTION
## Summary

- Adds opt-in `tui` feature flag with ratatui 0.29, crossterm 0.28, and tui-textarea 0.7
- Implements scrollable output pane, animated spinner (`◜◝◞◟` + elapsed time), and multiline input
- Exposes `pub fn spawn_tui(tx: Sender<String>, rx: Receiver<String>) -> JoinHandle<()>` for async integration
- Slash commands `/quit`, `/clear`, `/help` intercepted locally; ESC sends cancel sentinel

## File layout

| File | Purpose |
|------|---------|
| `src/tui/mod.rs` | App state, event loop, `spawn_tui` entry point |
| `src/tui/widgets.rs` | Spinner, output pane, spinner line renderers |
| `src/tui/theme.rs` | `Color::Rgb(0, 255, 70)` constants + style helpers |

## Test plan

- [ ] `cargo check --features tui` passes
- [ ] `cargo clippy --features tui -- -D warnings` clean
- [ ] Manual: `cargo run --features tui` displays layout, spinner animates, input submits
- [ ] PageUp/PageDown scrolls output, ESC cancels, `/quit` exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional terminal UI mode with interactive input, real-time output pane, and visual spinners for in-flight requests.
  * Built-in commands: /quit, /clear, /help.
  * Input area supporting multiline editing; Enter submits (Shift+Enter inserts newline).
  * Output scrolling (PageUp/PageDown) and request cancellation via Escape; cancelled requests are annotated.
  * Themed styling and refined spinner display; enable via the `tui` feature flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->