### PR TITLE
feat: launch TUI when hrafn is invoked without arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,6 +258,7 @@ libc = "0.2"
 [features]
 default = [
     "desktop",
+    "tui",
     "observability-prometheus",
     "skill-creation",
     "channel-telegram",

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,10 @@ async fn run_interactive_tui() -> Result<()> {
     use hrafn::tui::{CANCEL_SENTINEL, spawn_tui};
     use tokio::sync::mpsc;
 
+    if !std::io::stdout().is_terminal() {
+        return print_no_command_help();
+    }
+
     let (user_tx, mut user_rx) = mpsc::channel::<String>(32);
     let (agent_tx, agent_rx) = mpsc::channel::<String>(32);
 
@@ -96,7 +100,9 @@ async fn run_interactive_tui() -> Result<()> {
         }
     }
 
-    let _ = tui_handle.await;
+    tui_handle
+        .await
+        .map_err(|e| anyhow::anyhow!("TUI task panicked: {e}"))?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,35 @@ fn pause_after_no_command_help() {
     let _ = std::io::stdin().read_line(&mut line);
 }
 
+/// Launch the interactive TUI when `hrafn` is invoked without arguments.
+#[cfg(feature = "tui")]
+async fn run_interactive_tui() -> Result<()> {
+    use hrafn::tui::{CANCEL_SENTINEL, spawn_tui};
+    use tokio::sync::mpsc;
+
+    let (user_tx, mut user_rx) = mpsc::channel::<String>(32);
+    let (agent_tx, agent_rx) = mpsc::channel::<String>(32);
+
+    let tui_handle = spawn_tui(user_tx, agent_rx);
+
+    // Temporary echo-back loop until the real agent is wired (PR 3).
+    loop {
+        match user_rx.recv().await {
+            Some(msg) if msg == CANCEL_SENTINEL => {}
+            Some(msg) => {
+                let reply = format!("[echo] {msg}");
+                if agent_tx.send(reply).await.is_err() {
+                    break;
+                }
+            }
+            None => break,
+        }
+    }
+
+    let _ = tui_handle.await;
+    Ok(())
+}
+
 mod agent;
 mod approval;
 mod auth;
@@ -855,6 +884,9 @@ async fn main() -> Result<()> {
     }
 
     if std::env::args_os().len() <= 1 {
+        #[cfg(feature = "tui")]
+        return run_interactive_tui().await;
+        #[cfg(not(feature = "tui"))]
         return print_no_command_help();
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -124,13 +124,9 @@ impl App {
     fn push_output(&mut self, line: String) {
         self.output.push(line);
         if self.auto_scroll {
-            self.scroll_to_bottom();
+            // Use saturating max so Paragraph::scroll clamps to actual content
+            self.scroll_offset = u16::MAX;
         }
-    }
-
-    fn scroll_to_bottom(&mut self) {
-        let total = u16::try_from(self.output.len()).unwrap_or(u16::MAX);
-        self.scroll_offset = total.saturating_sub(1);
     }
 }
 
@@ -218,10 +214,10 @@ fn handle_key_event(app: &mut App, tx: &mpsc::Sender<String>, key: KeyEvent) -> 
         }
         KeyCode::PageDown => {
             app.scroll_offset = app.scroll_offset.saturating_add(10);
-            // Re-enable auto-scroll if we're near the bottom
+            // Re-enable auto-scroll if scrolled past content
             let total = u16::try_from(app.output.len()).unwrap_or(u16::MAX);
-            if app.scroll_offset >= total.saturating_sub(1) {
-                app.scroll_offset = total.saturating_sub(1);
+            if app.scroll_offset >= total {
+                app.scroll_offset = u16::MAX;
                 app.auto_scroll = true;
             }
             false

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -114,9 +114,11 @@ impl App {
             }
             _ => {
                 self.push_output(format!("> {text}"));
-                self.spinner = Some(SpinnerState::new("pondering"));
-                // Non-blocking send; if the channel is full we drop the message
-                let _ = tx.try_send(text);
+                if tx.try_send(text).is_ok() {
+                    self.spinner = Some(SpinnerState::new("pondering"));
+                } else {
+                    self.push_output("[send failed — channel full]".into());
+                }
             }
         }
     }
@@ -156,8 +158,8 @@ impl Drop for TerminalGuard {
 
 fn run_tui(tx: mpsc::Sender<String>, rx: &mut mpsc::Receiver<String>) -> io::Result<()> {
     terminal::enable_raw_mode()?;
+    let _guard = TerminalGuard; // ensures raw mode + alt screen are restored even on panic
     io::stdout().execute(EnterAlternateScreen)?;
-    let _guard = TerminalGuard;
 
     let backend = ratatui::backend::CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
@@ -202,8 +204,11 @@ fn handle_key_event(app: &mut App, tx: &mpsc::Sender<String>, key: KeyEvent) -> 
         KeyCode::Esc => {
             if app.spinner.is_some() {
                 app.spinner = None;
-                let _ = tx.try_send(CANCEL_SENTINEL.to_string());
-                app.push_output("[cancelled]".into());
+                if tx.try_send(CANCEL_SENTINEL.to_string()).is_ok() {
+                    app.push_output("[cancelled]".into());
+                } else {
+                    app.push_output("[cancel failed — channel full]".into());
+                }
             }
             false
         }


### PR DESCRIPTION
## Summary

- `hrafn` (no subcommand) now launches the interactive TUI instead of printing help
- Adds `tui` to default features so the binary ships with TUI enabled
- Falls back to help text when stdout is not a TTY (piped/cron)
- Includes a temporary echo-back loop; real agent wiring follows in a subsequent PR
- Falls back to the old help text when compiled without the `tui` feature

**Note on default feature:** Adding `tui` to `default` was explicitly requested by the maintainer (@5queezer) — this is the intended UX where `hrafn` with no args enters interactive mode.

Stacked on #175 (TUI module).

## Test plan

- [x] `cargo check` — compiles with default features (includes tui)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo run` in a terminal — enters TUI, text echoes back with `[echo]` prefix
- [ ] `cargo run | cat` — prints help (non-TTY fallback)
- [ ] `/quit` exits cleanly, terminal restored
- [ ] ESC cancels spinner, shows `[cancelled]`
- [ ] `cargo build --no-default-features --features desktop` — old help behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive terminal UI now enabled by default for no-argument runs: input textarea with placeholder, scrollable output pane, live spinner/elapsed indicator, submit via Enter, cancel with Esc, and commands (/quit, /clear, /help).
  * Keyboard navigation: PageUp/PageDown to adjust scroll and auto-scroll behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->