### PR TITLE
chore: add Claude Code rustfmt hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cargo fmt --all 2>/dev/null || true"
+            "command": "cargo fmt --all"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cargo fmt --all 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with a `PostToolUse` hook on `Write|Edit`
- Runs `cargo fmt --all` after every file edit to prevent formatting-only CI failures

## Test plan

- [x] `jq` validates the hook structure
- [ ] Edit a `.rs` file in Claude Code — formatting is auto-applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configuration to automatically run project code formatting after edit actions, improving code consistency and reducing manual formatting work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->