### PR TITLE
feat(tools): tiered schemas + ToolSearchStrategy trait

### DIFF
--- a/src/tools/mcp_deferred.rs
+++ b/src/tools/mcp_deferred.rs
@@ -198,21 +198,29 @@ impl ToolSearchStrategy for BM25Strategy {
 // ── DeferredMcpToolStub ──────────────────────────────────────────────────
 
 /// Shorten a description to its first sentence (up to ". "), capped at 120
-/// chars. Falls back to the full text truncated at 120 chars with "…".
-/// Truncation is always on a UTF-8 character boundary.
+/// characters. Falls back to the full text truncated at 120 characters with
+/// "…". Whitespace (newlines, tabs, runs of spaces) is collapsed to single
+/// spaces before truncation. Truncation is always on a character boundary.
 fn shorten(text: &str) -> String {
-    let raw = if let Some(pos) = text.find(". ") {
-        &text[..=pos]
+    // Normalize: collapse all whitespace runs to a single space and trim.
+    let normalized: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    let raw: &str = if let Some(pos) = normalized.find(". ") {
+        &normalized[..=pos]
     } else {
-        text
+        &normalized
     };
-    if raw.len() <= 120 {
+
+    if raw.chars().count() <= 120 {
         raw.to_string()
     } else {
-        let mut end = 119;
-        while end > 0 && !raw.is_char_boundary(end) {
-            end -= 1;
-        }
+        // char_indices().nth(119) yields the byte offset of the 120th character,
+        // which is always a valid UTF-8 boundary.
+        let end = raw
+            .char_indices()
+            .nth(119)
+            .map(|(i, _)| i)
+            .unwrap_or(raw.len());
         format!("{}…", &raw[..end])
     }
 }
@@ -557,6 +565,40 @@ mod tests {
     fn stub_uses_description_from_def() {
         let stub = make_stub("fs__read", "Read a file");
         assert_eq!(stub.description, "Read a file");
+    }
+
+    #[test]
+    fn shorten_normalizes_whitespace_and_truncates_on_char_boundary() {
+        // Embedded newline: sentence detection works after normalization.
+        let stub = make_stub("t__a", "First sentence.\nSecond sentence follows.");
+        assert_eq!(stub.stub_description, "First sentence.");
+
+        // Leading/trailing whitespace and tab are trimmed.
+        let stub = make_stub("t__b", "  \t  Clean description.  \n ");
+        assert_eq!(stub.stub_description, "Clean description.");
+
+        // 125 emoji (4 bytes each) = 125 characters > 120 → truncated.
+        // char_indices().nth(119) slices before the 120th char, so 119 chars
+        // remain before the ellipsis.
+        let desc: String = "🔥".repeat(125);
+        let stub = make_stub("t__c", &desc);
+        assert!(stub.stub_description.ends_with('…'));
+        let before = stub.stub_description.trim_end_matches('…');
+        assert_eq!(before.chars().count(), 119);
+        assert!(std::str::from_utf8(stub.stub_description.as_bytes()).is_ok());
+
+        // 122 accented chars (é = 2 bytes each) = 122 chars > 120 → truncated.
+        let desc: String = "é".repeat(122);
+        let stub = make_stub("t__d", &desc);
+        assert!(stub.stub_description.ends_with('…'));
+        let before = stub.stub_description.trim_end_matches('…');
+        assert_eq!(before.chars().count(), 119);
+
+        // Exactly 120 chars → passes through unchanged (no ellipsis).
+        let desc: String = "é".repeat(120);
+        let stub = make_stub("t__e", &desc);
+        assert!(!stub.stub_description.ends_with('…'));
+        assert_eq!(stub.stub_description.chars().count(), 120);
     }
 
     #[test]

--- a/src/tools/mcp_deferred.rs
+++ b/src/tools/mcp_deferred.rs
@@ -14,6 +14,21 @@ use crate::tools::mcp_protocol::McpToolDef;
 use crate::tools::mcp_tool::McpToolWrapper;
 use crate::tools::traits::{Tool, ToolSpec};
 
+// ── ToolSearchStrategy ───────────────────────────────────────────────────
+
+/// Strategy for ranking deferred tool stubs given a free-text query.
+/// Implementations may use BM25, embedding similarity, regex, etc.
+pub trait ToolSearchStrategy: Send + Sync {
+    /// Return up to `max_k` stubs ranked by relevance to `query`.
+    /// Stubs with zero relevance SHOULD be omitted.
+    fn search<'a>(
+        &self,
+        stubs: &'a [DeferredMcpToolStub],
+        query: &str,
+        max_k: usize,
+    ) -> Vec<&'a DeferredMcpToolStub>;
+}
+
 // ── BM25 Index ──────────────────────────────────────────────────────────
 
 /// Precomputed corpus statistics for BM25 scoring.
@@ -126,7 +141,73 @@ impl BM25Index {
     }
 }
 
+// ── BM25Strategy ─────────────────────────────────────────────────────────
+
+/// [`ToolSearchStrategy`] backed by Okapi BM25 (the default strategy).
+pub struct BM25Strategy {
+    index: BM25Index,
+}
+
+impl BM25Strategy {
+    pub fn build(stubs: &[DeferredMcpToolStub]) -> Self {
+        Self {
+            index: BM25Index::build(stubs),
+        }
+    }
+}
+
+impl ToolSearchStrategy for BM25Strategy {
+    fn search<'a>(
+        &self,
+        stubs: &'a [DeferredMcpToolStub],
+        query: &str,
+        max_k: usize,
+    ) -> Vec<&'a DeferredMcpToolStub> {
+        let terms: Vec<String> = query
+            .split(|c: char| c.is_whitespace() || c == '_' || c == '-')
+            .filter(|s| !s.is_empty())
+            .map(|t| t.to_ascii_lowercase())
+            .collect();
+        if terms.is_empty() {
+            return stubs.iter().take(max_k).collect();
+        }
+
+        let idfs = self.index.precompute_idfs(&terms);
+
+        let mut scored: Vec<(usize, f64)> = stubs
+            .iter()
+            .enumerate()
+            .map(|(idx, _)| (idx, self.index.score(&terms, &idfs, idx)))
+            .filter(|(_, score)| *score > 0.0)
+            .collect();
+
+        // Sort by score descending, then by name ascending for deterministic tie-breaking.
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| stubs[a.0].prefixed_name.cmp(&stubs[b.0].prefixed_name))
+        });
+        scored
+            .into_iter()
+            .take(max_k)
+            .map(|(idx, _)| &stubs[idx])
+            .collect()
+    }
+}
+
 // ── DeferredMcpToolStub ──────────────────────────────────────────────────
+
+/// Shorten a description to its first sentence (up to ". "), or truncate at
+/// 120 chars with "…", or pass through unchanged if short enough.
+fn shorten(text: &str) -> String {
+    if let Some(pos) = text.find(". ") {
+        text[..=pos].to_string()
+    } else if text.len() > 120 {
+        format!("{}…", &text[..119])
+    } else {
+        text.to_string()
+    }
+}
 
 /// A lightweight stub representing a known-but-not-yet-loaded MCP tool.
 /// Contains only the prefixed name, a human-readable description, and enough
@@ -137,6 +218,8 @@ pub struct DeferredMcpToolStub {
     pub prefixed_name: String,
     /// Human-readable description (extracted from the MCP tool definition).
     pub description: String,
+    /// Short form of description (≤ 120 chars) for system-prompt stubs.
+    pub stub_description: String,
     /// The full tool definition — stored so we can construct a wrapper later.
     def: McpToolDef,
 }
@@ -147,9 +230,11 @@ impl DeferredMcpToolStub {
             .description
             .clone()
             .unwrap_or_else(|| "MCP tool".to_string());
+        let stub_description = shorten(&description);
         Self {
             prefixed_name,
             description,
+            stub_description,
             def,
         }
     }
@@ -163,15 +248,15 @@ impl DeferredMcpToolStub {
 // ── DeferredMcpToolSet ───────────────────────────────────────────────────
 
 /// Collection of all deferred MCP tool stubs discovered at startup.
-/// Provides BM25-ranked keyword search for `tool_search`.
+/// Provides keyword search for `tool_search` via a pluggable [`ToolSearchStrategy`].
 #[derive(Clone)]
 pub struct DeferredMcpToolSet {
     /// All stubs — exposed for test construction.
     pub stubs: Vec<DeferredMcpToolStub>,
     /// Shared registry — exposed for test construction.
     pub registry: Arc<McpRegistry>,
-    /// Precomputed BM25 index over stub names + descriptions.
-    bm25: Arc<BM25Index>,
+    /// Search strategy used to rank stubs by relevance.
+    strategy: Arc<dyn ToolSearchStrategy>,
 }
 
 impl DeferredMcpToolSet {
@@ -188,21 +273,35 @@ impl DeferredMcpToolSet {
                 stubs.push(DeferredMcpToolStub::new(name, def));
             }
         }
-        let bm25 = Arc::new(BM25Index::build(&stubs));
+        let strategy: Arc<dyn ToolSearchStrategy> = Arc::new(BM25Strategy::build(&stubs));
         Self {
             stubs,
             registry,
-            bm25,
+            strategy,
         }
     }
 
     /// Build from pre-constructed stubs (for tests and internal use).
     pub(crate) fn from_stubs(stubs: Vec<DeferredMcpToolStub>, registry: Arc<McpRegistry>) -> Self {
-        let bm25 = Arc::new(BM25Index::build(&stubs));
+        let strategy: Arc<dyn ToolSearchStrategy> = Arc::new(BM25Strategy::build(&stubs));
         Self {
             stubs,
             registry,
-            bm25,
+            strategy,
+        }
+    }
+
+    /// Build from pre-constructed stubs with a custom search strategy.
+    /// Intended for tests and callers that need a non-BM25 strategy.
+    pub fn with_strategy(
+        stubs: Vec<DeferredMcpToolStub>,
+        registry: Arc<McpRegistry>,
+        strategy: Arc<dyn ToolSearchStrategy>,
+    ) -> Self {
+        Self {
+            stubs,
+            registry,
+            strategy,
         }
     }
 
@@ -229,43 +328,10 @@ impl DeferredMcpToolSet {
         self.stubs.iter().find(|s| s.prefixed_name == name)
     }
 
-    /// BM25 keyword search — returns stubs ranked by Okapi BM25 relevance.
-    /// Query is tokenized on whitespace, underscores, and hyphens.
+    /// Keyword search — returns stubs ranked by the configured [`ToolSearchStrategy`].
+    /// Defaults to Okapi BM25; use [`with_strategy`] to supply an alternative.
     pub fn search(&self, query: &str, max_results: usize) -> Vec<&DeferredMcpToolStub> {
-        let terms: Vec<String> = query
-            .split(|c: char| c.is_whitespace() || c == '_' || c == '-')
-            .filter(|s| !s.is_empty())
-            .map(|t| t.to_ascii_lowercase())
-            .collect();
-        if terms.is_empty() {
-            return self.stubs.iter().take(max_results).collect();
-        }
-
-        let idfs = self.bm25.precompute_idfs(&terms);
-
-        let mut scored: Vec<(usize, f64)> = self
-            .stubs
-            .iter()
-            .enumerate()
-            .map(|(idx, _)| (idx, self.bm25.score(&terms, &idfs, idx)))
-            .filter(|(_, score)| *score > 0.0)
-            .collect();
-
-        // Sort by score descending, then by name ascending for deterministic tie-breaking.
-        scored.sort_by(|a, b| {
-            b.1.partial_cmp(&a.1)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| {
-                    self.stubs[a.0]
-                        .prefixed_name
-                        .cmp(&self.stubs[b.0].prefixed_name)
-                })
-        });
-        scored
-            .into_iter()
-            .take(max_results)
-            .map(|(idx, _)| &self.stubs[idx])
-            .collect()
+        self.strategy.search(&self.stubs, query, max_results)
     }
 
     /// Activate a stub by name, returning a boxed [`Tool`].
@@ -448,7 +514,7 @@ pub fn build_deferred_tools_section(deferred: &DeferredMcpToolSet) -> String {
     for stub in &deferred.stubs {
         out.push_str(&stub.prefixed_name);
         out.push_str(" - ");
-        out.push_str(&stub.description);
+        out.push_str(&stub.stub_description);
         out.push('\n');
     }
     out.push_str("</available-deferred-tools>\n");
@@ -717,6 +783,68 @@ mod tests {
         let results = set.search("config database", 10);
         assert!(!results.is_empty());
         assert_eq!(results[0].prefixed_name, "server_b__read_config");
+    }
+
+    #[test]
+    fn build_deferred_section_uses_stub_description_not_full() {
+        // A description longer than 120 chars — the section should contain the
+        // truncated stub_description, not the full description.
+        let long_desc = "This is a very long description that intentionally exceeds one hundred and twenty characters so we can verify truncation behaviour in the system prompt section.";
+        assert!(long_desc.len() > 120);
+        let set = make_set(vec![make_stub("srv__tool", long_desc)]);
+        let stub = &set.stubs[0];
+        let section = build_deferred_tools_section(&set);
+        // The full description must NOT appear verbatim.
+        assert!(
+            !section.contains(long_desc),
+            "section must not contain the full long description"
+        );
+        // The stub_description (truncated form) must appear.
+        assert!(
+            section.contains(&stub.stub_description),
+            "section must contain the stub_description"
+        );
+        assert!(stub.stub_description.ends_with('…'));
+    }
+
+    #[test]
+    fn custom_strategy_is_used() {
+        use std::sync::Arc;
+
+        /// A trivial strategy that always returns stubs in their original order,
+        /// regardless of the query — useful for verifying `with_strategy` wiring.
+        struct FixedOrderStrategy;
+
+        impl ToolSearchStrategy for FixedOrderStrategy {
+            fn search<'a>(
+                &self,
+                stubs: &'a [DeferredMcpToolStub],
+                _query: &str,
+                max_k: usize,
+            ) -> Vec<&'a DeferredMcpToolStub> {
+                stubs.iter().take(max_k).collect()
+            }
+        }
+
+        let registry = Arc::new(
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(McpRegistry::connect_all(&[]))
+                .unwrap(),
+        );
+        let stubs = vec![
+            make_stub("a__first", "First tool"),
+            make_stub("b__second", "Second tool"),
+            make_stub("c__third", "Third tool"),
+        ];
+        let set = DeferredMcpToolSet::with_strategy(stubs, registry, Arc::new(FixedOrderStrategy));
+
+        // Regardless of query, FixedOrderStrategy returns stubs in original order.
+        let results = set.search("second", 3);
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].prefixed_name, "a__first");
+        assert_eq!(results[1].prefixed_name, "b__second");
+        assert_eq!(results[2].prefixed_name, "c__third");
     }
 
     #[test]

--- a/src/tools/mcp_deferred.rs
+++ b/src/tools/mcp_deferred.rs
@@ -149,7 +149,7 @@ pub struct BM25Strategy {
 }
 
 impl BM25Strategy {
-    pub fn build(stubs: &[DeferredMcpToolStub]) -> Self {
+    pub(crate) fn build(stubs: &[DeferredMcpToolStub]) -> Self {
         Self {
             index: BM25Index::build(stubs),
         }
@@ -197,15 +197,23 @@ impl ToolSearchStrategy for BM25Strategy {
 
 // ── DeferredMcpToolStub ──────────────────────────────────────────────────
 
-/// Shorten a description to its first sentence (up to ". "), or truncate at
-/// 120 chars with "…", or pass through unchanged if short enough.
+/// Shorten a description to its first sentence (up to ". "), capped at 120
+/// chars. Falls back to the full text truncated at 120 chars with "…".
+/// Truncation is always on a UTF-8 character boundary.
 fn shorten(text: &str) -> String {
-    if let Some(pos) = text.find(". ") {
-        text[..=pos].to_string()
-    } else if text.len() > 120 {
-        format!("{}…", &text[..119])
+    let raw = if let Some(pos) = text.find(". ") {
+        &text[..=pos]
     } else {
-        text.to_string()
+        text
+    };
+    if raw.len() <= 120 {
+        raw.to_string()
+    } else {
+        let mut end = 119;
+        while end > 0 && !raw.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &raw[..end])
     }
 }
 
@@ -494,9 +502,9 @@ impl Default for ActivatedToolSet {
 // ── System prompt helper ─────────────────────────────────────────────────
 
 /// Build the `<available-deferred-tools>` section for the system prompt.
-/// Lists only tool names so the LLM knows what is available without
-/// consuming context window on full schemas. Includes an instruction
-/// block that tells the LLM to call `tool_search` to activate them.
+/// Lists tool stubs (`name - stub_description`) so the LLM knows what is
+/// available without consuming context window on full schemas. Includes an
+/// instruction block that tells the LLM to call `tool_search` to activate them.
 pub fn build_deferred_tools_section(deferred: &DeferredMcpToolSet) -> String {
     if deferred.is_empty() {
         return String::new();

--- a/src/tools/traits.rs
+++ b/src/tools/traits.rs
@@ -51,22 +51,30 @@ pub trait Tool: Send + Sync {
     /// Short description for tiered context injection.
     /// Used in system-prompt stubs where the full description would waste tokens.
     /// Default: first sentence of `description()` (up to the first ". "),
-    /// capped at 120 chars. Falls back to the full description truncated at
-    /// 120 chars with "…". Truncation is always on a UTF-8 character boundary.
+    /// capped at 120 characters. Falls back to the full description truncated at
+    /// 120 characters with "…". Whitespace (newlines, tabs, runs of spaces) is
+    /// collapsed to single spaces. Truncation is always on a character boundary.
     fn stub_description(&self) -> String {
         let d = self.description();
-        let raw = if let Some(pos) = d.find(". ") {
-            &d[..=pos]
+        // Normalize: collapse all whitespace runs to a single space and trim.
+        let normalized: String = d.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        let raw: &str = if let Some(pos) = normalized.find(". ") {
+            &normalized[..=pos]
         } else {
-            d
+            &normalized
         };
-        if raw.len() <= 120 {
+
+        if raw.chars().count() <= 120 {
             raw.to_string()
         } else {
-            let mut end = 119;
-            while end > 0 && !raw.is_char_boundary(end) {
-                end -= 1;
-            }
+            // char_indices().nth(119) yields the byte offset of the 120th character,
+            // which is always a valid UTF-8 boundary.
+            let end = raw
+                .char_indices()
+                .nth(119)
+                .map(|(i, _)| i)
+                .unwrap_or(raw.len());
             format!("{}…", &raw[..end])
         }
     }
@@ -289,9 +297,9 @@ mod tests {
 
     #[test]
     fn stub_description_non_ascii_truncation_does_not_panic() {
-        // Description is all multi-byte characters (3 bytes each in UTF-8).
-        // Any byte-level slice at position 119 would land mid-character → panic
-        // without the char-boundary fix.
+        // 122 euro signs = 122 characters (> 120 limit), 3 bytes each in UTF-8.
+        // A byte-based slice at position 119 would land mid-character → panic.
+        // char_indices().nth(119) must yield a valid character boundary.
         struct UnicodeTool;
         #[async_trait]
         impl Tool for UnicodeTool {
@@ -299,8 +307,8 @@ mod tests {
                 "t"
             }
             fn description(&self) -> &str {
-                // "€" is 3 bytes; 45 repetitions = 135 bytes, > 120
-                "€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€"
+                // 122 × "€" = 122 chars, 366 bytes
+                "€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€"
             }
             fn parameters_schema(&self) -> serde_json::Value {
                 serde_json::json!({})
@@ -313,9 +321,13 @@ mod tests {
                 })
             }
         }
-        let stub = UnicodeTool.stub_description();
-        // Must not panic, must end with ellipsis, must be valid UTF-8.
-        assert!(stub.ends_with('…'));
-        assert!(std::str::from_utf8(stub.as_bytes()).is_ok());
+        let result = UnicodeTool.stub_description();
+        // Must truncate (122 chars > 120), end with ellipsis, be valid UTF-8.
+        // char_indices().nth(119) slices before the 120th char → 119 chars
+        // remain before the ellipsis.
+        assert!(result.ends_with('…'));
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+        let before_ellipsis = result.trim_end_matches('…');
+        assert_eq!(before_ellipsis.chars().count(), 119);
     }
 }

--- a/src/tools/traits.rs
+++ b/src/tools/traits.rs
@@ -51,15 +51,23 @@ pub trait Tool: Send + Sync {
     /// Short description for tiered context injection.
     /// Used in system-prompt stubs where the full description would waste tokens.
     /// Default: first sentence of `description()` (up to the first ". "),
-    /// otherwise the full description truncated at 120 chars with "…".
+    /// capped at 120 chars. Falls back to the full description truncated at
+    /// 120 chars with "…". Truncation is always on a UTF-8 character boundary.
     fn stub_description(&self) -> String {
         let d = self.description();
-        if let Some(pos) = d.find(". ") {
-            d[..=pos].to_string()
-        } else if d.len() > 120 {
-            format!("{}…", &d[..119])
+        let raw = if let Some(pos) = d.find(". ") {
+            &d[..=pos]
         } else {
-            d.to_string()
+            d
+        };
+        if raw.len() <= 120 {
+            raw.to_string()
+        } else {
+            let mut end = 119;
+            while end > 0 && !raw.is_char_boundary(end) {
+                end -= 1;
+            }
+            format!("{}…", &raw[..end])
         }
     }
 
@@ -248,5 +256,66 @@ mod tests {
         let stub = tool.stub();
         assert_eq!(stub.name, "sentence_tool");
         assert_eq!(stub.stub_description, "First sentence.");
+    }
+
+    #[test]
+    fn stub_description_caps_long_first_sentence() {
+        // A description whose first sentence is > 120 bytes should still be capped.
+        struct LongSentenceTool;
+        #[async_trait]
+        impl Tool for LongSentenceTool {
+            fn name(&self) -> &str {
+                "t"
+            }
+            fn description(&self) -> &str {
+                // First sentence is 130+ chars, terminated by ". "
+                "This first sentence is deliberately very long so that it exceeds the 120-character limit that we enforce on stub descriptions. Second sentence."
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({})
+            }
+            async fn execute(&self, _: serde_json::Value) -> anyhow::Result<ToolResult> {
+                Ok(ToolResult {
+                    success: true,
+                    output: String::new(),
+                    error: None,
+                })
+            }
+        }
+        let stub = LongSentenceTool.stub_description();
+        assert!(stub.ends_with('…'), "long first sentence must be truncated");
+        assert!(stub.len() <= 120 + '…'.len_utf8(), "must not exceed budget");
+    }
+
+    #[test]
+    fn stub_description_non_ascii_truncation_does_not_panic() {
+        // Description is all multi-byte characters (3 bytes each in UTF-8).
+        // Any byte-level slice at position 119 would land mid-character → panic
+        // without the char-boundary fix.
+        struct UnicodeTool;
+        #[async_trait]
+        impl Tool for UnicodeTool {
+            fn name(&self) -> &str {
+                "t"
+            }
+            fn description(&self) -> &str {
+                // "€" is 3 bytes; 45 repetitions = 135 bytes, > 120
+                "€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({})
+            }
+            async fn execute(&self, _: serde_json::Value) -> anyhow::Result<ToolResult> {
+                Ok(ToolResult {
+                    success: true,
+                    output: String::new(),
+                    error: None,
+                })
+            }
+        }
+        let stub = UnicodeTool.stub_description();
+        // Must not panic, must end with ellipsis, must be valid UTF-8.
+        assert!(stub.ends_with('…'));
+        assert!(std::str::from_utf8(stub.as_bytes()).is_ok());
     }
 }

--- a/src/tools/traits.rs
+++ b/src/tools/traits.rs
@@ -17,6 +17,13 @@ pub struct ToolSpec {
     pub parameters: serde_json::Value,
 }
 
+/// Lightweight stub for tiered context injection — name + short description only.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolStub {
+    pub name: String,
+    pub stub_description: String,
+}
+
 /// Core tool trait — implement for any capability
 #[async_trait]
 pub trait Tool: Send + Sync {
@@ -38,6 +45,29 @@ pub trait Tool: Send + Sync {
             name: self.name().to_string(),
             description: self.description().to_string(),
             parameters: self.parameters_schema(),
+        }
+    }
+
+    /// Short description for tiered context injection.
+    /// Used in system-prompt stubs where the full description would waste tokens.
+    /// Default: first sentence of `description()` (up to the first ". "),
+    /// otherwise the full description truncated at 120 chars with "…".
+    fn stub_description(&self) -> String {
+        let d = self.description();
+        if let Some(pos) = d.find(". ") {
+            d[..=pos].to_string()
+        } else if d.len() > 120 {
+            format!("{}…", &d[..119])
+        } else {
+            d.to_string()
+        }
+    }
+
+    /// Get a lightweight stub (name + short description) for tiered context injection.
+    fn stub(&self) -> ToolStub {
+        ToolStub {
+            name: self.name().to_string(),
+            stub_description: self.stub_description(),
         }
     }
 }
@@ -117,5 +147,106 @@ mod tests {
 
         assert!(!parsed.success);
         assert_eq!(parsed.error.as_deref(), Some("boom"));
+    }
+
+    struct SentenceTool;
+
+    #[async_trait]
+    impl Tool for SentenceTool {
+        fn name(&self) -> &str {
+            "sentence_tool"
+        }
+        fn description(&self) -> &str {
+            "First sentence. Second sentence follows here."
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                output: String::new(),
+                error: None,
+            })
+        }
+    }
+
+    struct LongTool;
+
+    #[async_trait]
+    impl Tool for LongTool {
+        fn name(&self) -> &str {
+            "long_tool"
+        }
+        fn description(&self) -> &str {
+            // 130-char description with no ". " separator
+            "This description is deliberately long and has no sentence break so truncation at 120 chars with an ellipsis should happen here."
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                output: String::new(),
+                error: None,
+            })
+        }
+    }
+
+    struct ShortTool;
+
+    #[async_trait]
+    impl Tool for ShortTool {
+        fn name(&self) -> &str {
+            "short_tool"
+        }
+        fn description(&self) -> &str {
+            "Short desc"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                output: String::new(),
+                error: None,
+            })
+        }
+    }
+
+    #[test]
+    fn stub_description_truncates_at_first_sentence() {
+        let tool = SentenceTool;
+        assert_eq!(tool.stub_description(), "First sentence.");
+    }
+
+    #[test]
+    fn stub_description_truncates_long_description_with_ellipsis() {
+        let tool = LongTool;
+        let desc = tool.description();
+        assert!(
+            desc.len() > 120,
+            "precondition: description must be > 120 chars"
+        );
+        let stub = tool.stub_description();
+        assert!(stub.ends_with('…'));
+        // The stub should be the first 119 chars + the ellipsis character (3 bytes in UTF-8)
+        assert_eq!(stub, format!("{}…", &desc[..119]));
+    }
+
+    #[test]
+    fn stub_description_passes_short_description_unchanged() {
+        let tool = ShortTool;
+        assert_eq!(tool.stub_description(), "Short desc");
+    }
+
+    #[test]
+    fn stub_returns_name_and_stub_description() {
+        let tool = SentenceTool;
+        let stub = tool.stub();
+        assert_eq!(stub.name, "sentence_tool");
+        assert_eq!(stub.stub_description, "First sentence.");
     }
 }


### PR DESCRIPTION
## Summary
- Add `stub_description()` and `stub()` default methods to the `Tool` trait so every tool can expose a short one-liner independently of its full JSON schema
- Introduce `ToolSearchStrategy` — an object-safe trait decoupling search back-ends from `DeferredMcpToolSet`, enabling future embedding/intent-based strategies alongside BM25
- `build_deferred_tools_section()` now renders stub descriptions (first sentence, ≤120 chars) in the system prompt rather than the full description

## Changes
- `src/tools/traits.rs`: `ToolStub` struct, `stub_description()` default (first sentence / 120-char truncation), `stub()` default
- `src/tools/mcp_deferred.rs`: `ToolSearchStrategy` trait, `BM25Strategy` wrapper (scoring logic unchanged), `stub_description` field on `DeferredMcpToolStub`, `with_strategy()` constructor on `DeferredMcpToolSet`

## Test plan
- [x] 28 unit tests pass (`tools::traits` + `tools::mcp_deferred`)
- [x] `cargo fmt` and `cargo clippy -D warnings` clean
- [x] `custom_strategy_is_used` test confirms strategy is wired through
- [x] `build_deferred_section_uses_stub_description_not_full` confirms short form in system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tool descriptions now show a shortened "stub" form—prefer the first sentence or truncate to 120 chars with an ellipsis; UTF‑8 safe.

* **Refactor**
  * Search now uses a pluggable ranking strategy with a default BM25 implementation; custom ranking can be injected to control ordering.

* **Tests**
  * Added tests for description shortening, UTF‑8 truncation, and custom search ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->