### PR TITLE
fix(build): move TUI deps out of platform-gated section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,12 @@ opentelemetry-otlp = { version = "0.31", default-features = false, features = ["
 # Serial port for peripheral communication (STM32, etc.)
 tokio-serial = { version = "5", default-features = false, optional = true }
 
+# TUI interface (ratatui + crossterm + tui-textarea)
+# These are pure-Rust/termios crates that work on all Unix targets including Android.
+ratatui = { version = "0.29", optional = true, default-features = false, features = ["crossterm"] }
+crossterm = { version = "0.28", optional = true }
+tui-textarea = { version = "0.7", optional = true, default-features = false, features = ["crossterm"] }
+
 # USB device enumeration (hardware discovery) — only on platforms nusb supports
 # (Linux, macOS, Windows). Android/Termux uses target_os="android" and is excluded.
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
@@ -231,11 +237,6 @@ cpal = { version = "0.15", optional = true }
 
 # Terminal QR rendering for WhatsApp Web pairing flow.
 qrcode = { version = "0.14", optional = true }
-
-# TUI interface (ratatui + crossterm + tui-textarea)
-ratatui = { version = "0.29", optional = true, default-features = false, features = ["crossterm"] }
-crossterm = { version = "0.28", optional = true }
-tui-textarea = { version = "0.7", optional = true, default-features = false, features = ["crossterm"] }
 
 # WhatsApp Web client (wa-rs) — optional, enable with --features whatsapp-web
 # Uses wa-rs for Bot and Client, wa-rs-core for storage traits, custom rusqlite backend avoids Diesel conflict.


### PR DESCRIPTION
## Summary
- The `aarch64-linux-android` release build fails with 11 "unresolved crate" errors because `ratatui`, `crossterm`, and `tui-textarea` are declared inside `[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]`
- Android's `target_os` is `"android"`, not `"linux"`, so the deps are excluded — but the `tui` feature (in `default`) still compiles `pub mod tui;`
- Move TUI deps to ungated `[dependencies]` — they are `optional = true` and pure-Rust/termios-based, working on all Unix targets

## Changes
- `Cargo.toml`: relocate 3 TUI dependency lines from the platform-gated `[target.cfg(...)]` section to the main `[dependencies]` section

## Test plan
- [x] `cargo check --locked` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — 7 pre-existing failures on master, no new failures
- [ ] CI: `release-beta-on-push` Android build should pass

Fixes: https://github.com/5queezer/hrafn/actions/runs/24304000675/job/70962174883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency organization to improve project maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->