### PR TITLE
feat(memory): add access tracking for synaptic retrieval (ADR-005 Phase 1)

### DIFF
--- a/docs/architecture/adr-005-synaptic-memory-retrieval.md
+++ b/docs/architecture/adr-005-synaptic-memory-retrieval.md
@@ -49,19 +49,32 @@ Record timestamps whenever a memory entry is stored or recalled.
 This produces an "access spike train" per entry: a time-series of
 access events that enables temporal association scoring.
 
-**Scope:** New `memory_access_log` table in the SQLite backend,
-populated by `store()` and `recall()` implementations.
+**Scope:** New `memory_access_log` table in the audit database
+(`audit.db`), populated via the existing `AuditedMemory<M>`
+decorator (`src/memory/audit.rs`). This extends the audit
+infrastructure rather than adding a parallel tracking mechanism
+— the existing `memory_audit` table already tracks operation-level
+events (Store/Recall) but does not record which specific memory
+entries were returned by each recall, which is what Phase 2 needs
+for spike train construction.
 
 ```sql
-CREATE TABLE memory_access_log (
+CREATE TABLE IF NOT EXISTS memory_access_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
     memory_id   TEXT NOT NULL,
-    accessed_at TEXT NOT NULL,  -- RFC 3339
-    access_type TEXT NOT NULL,  -- 'store' | 'recall'
-    FOREIGN KEY (memory_id)
-        REFERENCES memories(id) ON DELETE CASCADE
+    memory_key  TEXT NOT NULL,
+    query       TEXT NOT NULL,
+    score       REAL,
+    namespace   TEXT,
+    session_id  TEXT,
+    accessed_at TEXT NOT NULL   -- RFC 3339
 );
-CREATE INDEX idx_access_log_memory
+CREATE INDEX IF NOT EXISTS idx_access_log_memory_id
     ON memory_access_log(memory_id);
+CREATE INDEX IF NOT EXISTS idx_access_log_accessed_at
+    ON memory_access_log(accessed_at);
+CREATE INDEX IF NOT EXISTS idx_access_log_memory_id_at
+    ON memory_access_log(memory_id, accessed_at);
 ```
 
 **Prerequisite fix:** `RetrievalPipeline::cache_key()` currently
@@ -117,9 +130,9 @@ pub fn hybrid_merge(
 ) -> Vec<ScoredResult>
 ```
 
-All existing call sites (in `sqlite.rs`, `muninndb.rs`, and
-`backend.rs`) must be updated. When `temporal_weight = 0.0`,
-callers pass an empty slice for `temporal_results`.
+The existing call site in `sqlite.rs` must be updated. When
+`temporal_weight = 0.0`, callers pass an empty slice for
+`temporal_results`.
 
 A configurable `temporal_candidate_cap` (default: 20) limits the
 candidate set size before temporal scoring runs, bounding the
@@ -135,23 +148,20 @@ final = w_vec * vector
 
 #### Weight defaults and migration
 
-The current defaults are `w_vec = 0.5`, `w_kw = 0.3` (sum 0.8).
-Phase 2 introduces `w_temp = 0.2` (new sum 1.0). This changes
-the effective scale of existing scores.
-
-**Migration path:** Existing `[memory]` configs that set custom
-`vector_weight` / `keyword_weight` values will have
-`temporal_weight` default to `0.0` (opt-in), so their scoring
-is unchanged. When a user explicitly enables `temporal_weight`,
-the `[memory]` settings handler renormalizes all three weights
-to sum to 1.0:
+The current defaults are `w_vec = 0.7`, `w_kw = 0.3` (sum 1.0).
+Phase 2 introduces `w_temp` (default `0.0`, opt-in). When a user
+explicitly sets `temporal_weight > 0.0`, all three weights are
+renormalized to sum to 1.0:
 
 ```text
 w_i' = w_i / (w_vec + w_kw + w_temp)
 ```
 
+For example, setting `temporal_weight = 0.2` with the current
+defaults yields `w_vec = 0.583`, `w_kw = 0.25`, `w_temp = 0.167`.
+
 If all weights are zero, the system falls back to hard-coded
-defaults (`w_vec = 0.625`, `w_kw = 0.375`). This guarantees no
+defaults (`w_vec = 0.7`, `w_kw = 0.3`). This guarantees no
 behavioral change for existing configurations.
 
 **Risk:** Medium. Changes retrieval scoring, but `w_temp`

--- a/docs/architecture/adr-005-synaptic-memory-retrieval.md
+++ b/docs/architecture/adr-005-synaptic-memory-retrieval.md
@@ -4,196 +4,230 @@
 
 **Date:** 2026-04-13
 
-**References:** [SynapticRAG (Hou et al., ACL 2025 Findings)](https://arxiv.org/abs/2410.13553v2)
+**References:**
+[SynapticRAG (Hou et al., ACL 2025 Findings)](https://arxiv.org/abs/2410.13553v2)
 
 ## Context
 
-Hrafn's memory retrieval pipeline (`src/memory/retrieval.rs`) operates in three
-stages: hot LRU cache, FTS5 keyword search, and vector similarity with hybrid
-merge. Time is treated only as a passive decay penalty (`src/memory/decay.rs`),
-and the knowledge graph (`src/memory/knowledge_graph.rs`) is not integrated into
-the recall path.
+Hrafn's memory retrieval pipeline (`src/memory/retrieval.rs`) operates
+in three stages: hot LRU cache, FTS5 keyword search, and vector
+similarity with hybrid merge. Time is treated only as a passive decay
+penalty (`src/memory/decay.rs`), and the knowledge graph
+(`src/memory/knowledge_graph.rs`) is not integrated into the recall
+path.
 
-This works well for direct lookups but degrades when the user references
-something from a prior conversation where the semantic signal alone is
-ambiguous. The system cannot follow temporal chains of reasoning: "we discussed
-X, which led to Y, which led to Z." It also cannot model how memories activate
-each other through co-occurrence patterns across sessions.
+This works well for direct lookups but degrades when the user
+references something from a prior conversation where the semantic
+signal alone is ambiguous. The system cannot follow temporal chains
+of reasoning: "we discussed X, which led to Y, which led to Z." It
+also cannot model how memories activate each other through
+co-occurrence patterns across sessions.
 
 SynapticRAG demonstrates that combining temporal association with
-biologically-inspired activation thresholds yields up to 14.66% improvement on
-conversational memory retrieval benchmarks (SMRCs, PerLTQA) over standard
-vector-similarity RAG.
+biologically-inspired activation thresholds yields up to 14.66%
+improvement on conversational memory retrieval benchmarks (SMRCs,
+PerLTQA) over standard vector-similarity RAG.
 
 ## Decision Drivers
 
-- Hrafn is a conversational agent where multi-turn, multi-session temporal
-  context matters.
-- The memory infrastructure is already 80% ready: embeddings, vector similarity,
-  knowledge graph with traversal, time-decay, importance scores, and a staged
-  retrieval pipeline with pluggable stages.
+- Hrafn is a conversational agent where multi-turn, multi-session
+  temporal context matters.
+- The memory infrastructure is already 80% ready: embeddings, vector
+  similarity, knowledge graph with traversal, time-decay, importance
+  scores, and a staged retrieval pipeline with pluggable stages.
 - The knowledge graph exists but has no retrieval-time role.
-- Core memories are exempt from decay but have no mechanism to strengthen
-  retrieval of related non-core memories.
+- Core memories are exempt from decay but have no mechanism to
+  strengthen retrieval of related non-core memories.
 
 ## Proposed Changes
 
 ### 1. Memory Access Tracking
 
-Record timestamps whenever a memory entry is stored or recalled. This produces
-an "access spike train" per entry: a time-series of access events that enables
-temporal association scoring.
+Record timestamps whenever a memory entry is stored or recalled.
+This produces an "access spike train" per entry: a time-series of
+access events that enables temporal association scoring.
 
-**Scope:** New `memory_access_log` table in the SQLite backend, populated by
-`store()` and `recall()` implementations.
+**Scope:** New `memory_access_log` table in the SQLite backend,
+populated by `store()` and `recall()` implementations.
 
 ```sql
 CREATE TABLE memory_access_log (
-    memory_id TEXT NOT NULL,
+    memory_id   TEXT NOT NULL,
     accessed_at TEXT NOT NULL,  -- RFC 3339
     access_type TEXT NOT NULL,  -- 'store' | 'recall'
-    FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
+    FOREIGN KEY (memory_id)
+        REFERENCES memories(id) ON DELETE CASCADE
 );
-CREATE INDEX idx_access_log_memory ON memory_access_log(memory_id);
+CREATE INDEX idx_access_log_memory
+    ON memory_access_log(memory_id);
 ```
 
 **Risk:** Low. Additive schema change, no existing behavior modified.
 
 ### 2. Temporal Association Scoring
 
-Augment `hybrid_merge` in `src/memory/vector.rs` with a temporal association
-signal. Given two candidate memories A and B, compute how often they were
-accessed near each other in time using a simplified DTW-inspired alignment:
+Augment `hybrid_merge` in `src/memory/vector.rs` with a temporal
+association signal. Given two candidate memories A and B, compute
+how often they were accessed near each other in time using a
+simplified DTW-inspired alignment:
 
-```
-T_score(A, B) = sigmoid(alignment_score(spike_train_A, spike_train_B))
+```text
+T_score(A, B) = sigmoid(
+    alignment_score(spike_train_A, spike_train_B)
+)
 ```
 
 The combined propagation score becomes:
 
-```
+```text
 P_score(A, B) = T_score(A, B) * cosine_similarity(A, B)
 ```
 
 Integrate into hybrid merge as a third weighted signal:
 
-```
-final = w_vec * vector + w_kw * keyword + w_temp * temporal_association
+```text
+final = w_vec * vector
+      + w_kw  * keyword
+      + w_temp * temporal_association
 ```
 
-Default weights: `w_vec = 0.5`, `w_kw = 0.3`, `w_temp = 0.2`. Configurable via
-`[memory]` settings to allow disabling (`w_temp = 0.0`) with no behavioral
-change.
+Default weights: `w_vec = 0.5`, `w_kw = 0.3`, `w_temp = 0.2`.
+Configurable via `[memory]` settings. When `w_temp` is set to
+`0.0`, the `[memory]` settings handler renormalizes the remaining
+weights to preserve their relative proportion:
 
-**Risk:** Medium. Changes retrieval scoring, but gated behind a weight that
-defaults conservatively and can be zeroed.
+```text
+w_vec' = w_vec / (w_vec + w_kw)
+w_kw'  = w_kw  / (w_vec + w_kw)
+```
+
+If both `w_vec` and `w_kw` are also zero, the system falls back to
+hard-coded defaults (`w_vec = 0.5`, `w_kw = 0.3`). This guarantees
+no behavioral change when disabling temporal scoring.
+
+**Risk:** Medium. Changes retrieval scoring, but gated behind a
+weight that defaults conservatively and can be zeroed.
 
 ### 3. Stimulus Propagation on the Knowledge Graph
 
-When a query activates a set of candidate memory nodes, propagate activation
-energy through the knowledge graph edges with decay:
+When a query activates a set of candidate memory nodes, propagate
+activation energy through the knowledge graph edges with decay:
 
-```
+```text
 S_child = S_parent * P_score(parent, child)
 ```
 
-Nodes that accumulate sufficient stimulus from multiple convergent paths are
-included in the result set, even if they would not have been retrieved by direct
-similarity alone. This gives the knowledge graph a retrieval-time role.
+Nodes that accumulate sufficient stimulus from multiple convergent
+paths are included in the result set, even if they would not have
+been retrieved by direct similarity alone. This gives the knowledge
+graph a retrieval-time role.
 
 Propagation respects existing edge semantics:
+
 - `Extends` / `Uses`: full propagation weight.
 - `Replaces`: propagate only if the replacement is newer.
-- `AuthoredBy` / `AppliesTo`: reduced weight (0.3x) to avoid expert-node
-  fan-out dominating results.
+- `AuthoredBy` / `AppliesTo`: reduced weight (0.3x) to avoid
+  expert-node fan-out dominating results.
 
-A configurable `stim_threshold` (default: 0.037, per the paper's optimized
-value) gates which nodes qualify for propagation.
+A configurable `stim_threshold` (default: 0.037, per the paper's
+optimized value) gates which nodes qualify for propagation.
 
-**Risk:** Medium-High. Introduces a new retrieval path through the knowledge
-graph. Should be feature-gated and opt-in initially.
+**Risk:** Medium-High. Introduces a new retrieval path through the
+knowledge graph. Should be feature-gated and opt-in initially.
 
 ### 4. Leaky Integrate-and-Fire Memory Selection
 
-Replace the fixed `limit` parameter with a dynamic threshold mechanism inspired
-by the LIF neuron model:
+Replace the fixed `limit` parameter with a dynamic threshold
+mechanism inspired by the LIF neuron model:
 
-```
+```text
 tau * dV/dt = -V(t) + I(t)
 fire when V >= V_th
 ```
 
 Where:
+
 - `V` is the membrane potential (accumulated retrieval confidence).
 - `I(t)` is the input current from retrieval scores.
-- `tau` is a dynamic time constant: frequently-accessed memories respond faster
-  (low tau), rarely-accessed memories need sustained stimulation (high tau).
+- `tau` is a dynamic time constant: frequently-accessed memories
+  respond faster (low tau), rarely-accessed memories need sustained
+  stimulation (high tau).
 - `V_th` is the firing threshold (default: 0.099, per paper).
 
 This maps naturally onto existing Hrafn concepts:
+
 - `importance` score influences initial membrane potential.
 - `decay.rs` half-life maps to the leaky time constant.
-- `MemoryCategory::Core` (exempt from decay) acts as a permanently low
-  firing threshold.
+- `MemoryCategory::Core` (exempt from decay) acts as a permanently
+  low firing threshold.
 
-The `limit` parameter becomes a hard cap rather than the sole selection
-criterion.
+The `limit` parameter becomes a hard cap rather than the sole
+selection criterion.
 
-**Risk:** Medium. Changes how many memories are returned, but the hard cap
-preserves backward compatibility.
+**Risk:** Medium. Changes how many memories are returned, but the
+hard cap preserves backward compatibility.
 
 ## Implementation Plan
 
-| Phase | Scope | Risk | Depends On |
-|-------|-------|------|------------|
-| 1. Access tracking | New table + logging in SQLite backend | Low | -- |
-| 2. Temporal scoring | New scoring function + hybrid merge extension | Medium | Phase 1 |
-| 3. Graph propagation | New retrieval path, feature-gated | Medium-High | Phase 2 |
-| 4. LIF selection | Dynamic limit replacement | Medium | Phase 2 |
+| Phase | Scope                      | Risk        | Depends On |
+|-------|----------------------------|-------------|------------|
+| 1     | Access tracking: new table | Low         | --         |
+| 2     | Temporal scoring: hybrid   | Medium      | Phase 1    |
+| 3     | Graph propagation (gated)  | Medium-High | Phase 2    |
+| 4     | LIF selection              | Medium      | Phase 2    |
 
-Each phase is a separate PR. Phase 1 is prerequisite for all others. Phases 3
-and 4 are independent of each other.
+Each phase is a separate PR. Phase 1 is prerequisite for all
+others. Phases 3 and 4 are independent of each other.
 
 ## Alternatives Considered
 
 ### A. Ebbinghaus forgetting curve (MemoryBank approach)
 
-Already partially implemented via `decay.rs`. SynapticRAG subsumes this: the
-LIF time constant generalizes exponential decay with stimulus-driven
-reactivation. The existing decay module would remain for backward compatibility
-but become redundant once Phase 4 lands.
+Already partially implemented via `decay.rs`. SynapticRAG subsumes
+this: the LIF time constant generalizes exponential decay with
+stimulus-driven reactivation. The existing decay module would remain
+for backward compatibility but become redundant once Phase 4 lands.
 
 ### B. Recency-biased retrieval without temporal association
 
-Simpler: just boost recent memories. But this fails when the relevant memory is
-old but was temporally co-accessed with the current topic. SynapticRAG's DTW
-alignment captures this pattern; pure recency does not.
+Simpler: just boost recent memories. But this fails when the
+relevant memory is old but was temporally co-accessed with the
+current topic. SynapticRAG's DTW alignment captures this pattern;
+pure recency does not.
 
 ### C. Full graph neural network for retrieval
 
-More powerful but far heavier: requires training, GPU inference, and a
-dependency on a GNN framework. SynapticRAG's analytical propagation model
-achieves strong results without learned parameters, fitting Hrafn's
-no-heavy-dependencies principle.
+More powerful but far heavier: requires training, GPU inference,
+and a dependency on a GNN framework. SynapticRAG's analytical
+propagation model achieves strong results without learned
+parameters, fitting Hrafn's no-heavy-dependencies principle.
 
 ## Consequences
 
 **Positive:**
-- Up to ~14% retrieval accuracy improvement on temporal conversational queries.
-- Knowledge graph gains a retrieval-time purpose, justifying its maintenance
-  cost.
-- Memory system becomes more biologically plausible, with natural concepts
-  (activation, decay, threshold) that are easier to reason about and tune.
+
+- Up to ~14% retrieval accuracy improvement on temporal
+  conversational queries.
+- Knowledge graph gains a retrieval-time purpose, justifying its
+  maintenance cost.
+- Memory system becomes more biologically plausible, with natural
+  concepts (activation, decay, threshold) that are easier to reason
+  about and tune.
 
 **Negative:**
-- Access logging adds write amplification to every store/recall operation.
-- Temporal scoring adds O(n^2) pairwise computation on candidate sets (mitigated
-  by the candidate pre-filter from FTS/vector stages).
+
+- Access logging adds write amplification to every store/recall
+  operation.
+- Temporal scoring adds O(n^2) pairwise computation on candidate
+  sets (mitigated by the candidate pre-filter from FTS/vector
+  stages).
 - Graph propagation adds latency proportional to graph density.
-- Four-phase rollout means the full benefit is not realized until all phases
-  land.
+- Four-phase rollout means the full benefit is not realized until
+  all phases land.
 
 **Neutral:**
-- Existing `decay.rs` remains functional throughout. No breaking changes to the
-  `Memory` trait.
-- Feature-gating phases 3-4 allows production use of phases 1-2 independently.
+
+- Existing `decay.rs` remains functional throughout. No breaking
+  changes to the `Memory` trait.
+- Feature-gating phases 3-4 allows production use of phases 1-2
+  independently.

--- a/docs/architecture/adr-005-synaptic-memory-retrieval.md
+++ b/docs/architecture/adr-005-synaptic-memory-retrieval.md
@@ -25,8 +25,10 @@ co-occurrence patterns across sessions.
 
 SynapticRAG demonstrates that combining temporal association with
 biologically-inspired activation thresholds yields up to 14.66%
-improvement on conversational memory retrieval benchmarks (SMRCs,
-PerLTQA) over standard vector-similarity RAG.
+improvement on conversational memory retrieval benchmarks — tested
+across four datasets in English, Chinese, and Japanese (SMRCs-EN,
+SMRCs-JA, PerLTQA-EN, PerLTQA-CN) — over standard vector-similarity
+RAG.
 
 ## Decision Drivers
 
@@ -62,28 +64,68 @@ CREATE INDEX idx_access_log_memory
     ON memory_access_log(memory_id);
 ```
 
+**Prerequisite fix:** `RetrievalPipeline::cache_key()` currently
+omits the `since`/`until` parameters, so two calls with the same
+query but different time ranges share a cache entry. This must be
+fixed before Phase 1, since temporal scoring makes time-range
+queries more likely. Add `since` and `until` to the cache key
+format string.
+
 **Risk:** Low. Additive schema change, no existing behavior modified.
 
 ### 2. Temporal Association Scoring
 
-Augment `hybrid_merge` in `src/memory/vector.rs` with a temporal
-association signal. Given two candidate memories A and B, compute
-how often they were accessed near each other in time using a
-simplified DTW-inspired alignment:
+Phase 2 adds a **query-relative** temporal signal. For each
+candidate memory C, compute how closely C's access spike train
+aligns with the spike train of the current query context (the
+memories most recently stored or recalled in this session):
 
 ```text
-T_score(A, B) = sigmoid(
-    alignment_score(spike_train_A, spike_train_B)
+T_score(query_ctx, C) = sigmoid(
+    alignment_score(spike_train_query, spike_train_C)
 )
 ```
 
-The combined propagation score becomes:
+This produces one temporal score per candidate, fitting naturally
+into `hybrid_merge` as a third input list alongside vector and
+keyword results.
+
+The separate **pairwise** formula used in Phase 3 (graph
+propagation) is distinct:
 
 ```text
 P_score(A, B) = T_score(A, B) * cosine_similarity(A, B)
 ```
 
-Integrate into hybrid merge as a third weighted signal:
+Phase 3 uses `P_score` as edge weights for stimulus propagation
+between knowledge graph nodes.
+
+#### `hybrid_merge` API change
+
+The current signature accepts `vector_results` and
+`keyword_results`. Phase 2 adds a third parameter:
+
+```rust
+pub fn hybrid_merge(
+    vector_results: &[(String, f32)],
+    keyword_results: &[(String, f32)],
+    temporal_results: &[(String, f32)],  // new
+    vector_weight: f32,
+    keyword_weight: f32,
+    temporal_weight: f32,                // new
+    limit: usize,
+) -> Vec<ScoredResult>
+```
+
+All existing call sites (in `sqlite.rs`, `muninndb.rs`, and
+`backend.rs`) must be updated. When `temporal_weight = 0.0`,
+callers pass an empty slice for `temporal_results`.
+
+A configurable `temporal_candidate_cap` (default: 20) limits the
+candidate set size before temporal scoring runs, bounding the
+O(n^2) DTW alignment cost.
+
+#### Scoring formula
 
 ```text
 final = w_vec * vector
@@ -91,22 +133,29 @@ final = w_vec * vector
       + w_temp * temporal_association
 ```
 
-Default weights: `w_vec = 0.5`, `w_kw = 0.3`, `w_temp = 0.2`.
-Configurable via `[memory]` settings. When `w_temp` is set to
-`0.0`, the `[memory]` settings handler renormalizes the remaining
-weights to preserve their relative proportion:
+#### Weight defaults and migration
+
+The current defaults are `w_vec = 0.5`, `w_kw = 0.3` (sum 0.8).
+Phase 2 introduces `w_temp = 0.2` (new sum 1.0). This changes
+the effective scale of existing scores.
+
+**Migration path:** Existing `[memory]` configs that set custom
+`vector_weight` / `keyword_weight` values will have
+`temporal_weight` default to `0.0` (opt-in), so their scoring
+is unchanged. When a user explicitly enables `temporal_weight`,
+the `[memory]` settings handler renormalizes all three weights
+to sum to 1.0:
 
 ```text
-w_vec' = w_vec / (w_vec + w_kw)
-w_kw'  = w_kw  / (w_vec + w_kw)
+w_i' = w_i / (w_vec + w_kw + w_temp)
 ```
 
-If both `w_vec` and `w_kw` are also zero, the system falls back to
-hard-coded defaults (`w_vec = 0.5`, `w_kw = 0.3`). This guarantees
-no behavioral change when disabling temporal scoring.
+If all weights are zero, the system falls back to hard-coded
+defaults (`w_vec = 0.625`, `w_kw = 0.375`). This guarantees no
+behavioral change for existing configurations.
 
-**Risk:** Medium. Changes retrieval scoring, but gated behind a
-weight that defaults conservatively and can be zeroed.
+**Risk:** Medium. Changes retrieval scoring, but `w_temp`
+defaults to `0.0` for existing configs and can be zeroed.
 
 ### 3. Stimulus Propagation on the Knowledge Graph
 
@@ -122,6 +171,39 @@ paths are included in the result set, even if they would not have
 been retrieved by direct similarity alone. This gives the knowledge
 graph a retrieval-time role.
 
+#### KnowledgeNode-to-MemoryEntry bridge
+
+`KnowledgeNode` and `MemoryEntry` are separate data structures
+with independent UUIDs. Phase 3 requires an explicit link between
+them so that stimulus propagation on the knowledge graph can
+influence memory recall scores.
+
+A new join table bridges the two:
+
+```sql
+CREATE TABLE memory_kg_links (
+    memory_id  TEXT NOT NULL,
+    kg_node_id TEXT NOT NULL,
+    PRIMARY KEY (memory_id, kg_node_id),
+    FOREIGN KEY (memory_id)
+        REFERENCES memories(id) ON DELETE CASCADE,
+    FOREIGN KEY (kg_node_id)
+        REFERENCES nodes(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_kg_links_node
+    ON memory_kg_links(kg_node_id);
+```
+
+Links are populated during memory consolidation
+(`consolidation.rs`): when a Core memory update is stored, the
+consolidation engine queries the knowledge graph for matching
+nodes (by FTS similarity on the memory content) and inserts
+links for any matches above a configurable threshold. Links can
+also be created explicitly via the `memory_store` tool when
+a `kg_node_id` is provided.
+
+#### Edge-weighted propagation
+
 Propagation respects existing edge semantics:
 
 - `Extends` / `Uses`: full propagation weight.
@@ -133,7 +215,8 @@ A configurable `stim_threshold` (default: 0.037, per the paper's
 optimized value) gates which nodes qualify for propagation.
 
 **Risk:** Medium-High. Introduces a new retrieval path through the
-knowledge graph. Should be feature-gated and opt-in initially.
+knowledge graph and a new schema dependency between the memory
+and KG tables. Should be feature-gated and opt-in initially.
 
 ### 4. Leaky Integrate-and-Fire Memory Selection
 
@@ -219,8 +302,8 @@ parameters, fitting Hrafn's no-heavy-dependencies principle.
 - Access logging adds write amplification to every store/recall
   operation.
 - Temporal scoring adds O(n^2) pairwise computation on candidate
-  sets (mitigated by the candidate pre-filter from FTS/vector
-  stages).
+  sets, bounded by `temporal_candidate_cap` (default 20, so at
+  most ~400 alignments per query).
 - Graph propagation adds latency proportional to graph density.
 - Four-phase rollout means the full benefit is not realized until
   all phases land.

--- a/docs/architecture/adr-005-synaptic-memory-retrieval.md
+++ b/docs/architecture/adr-005-synaptic-memory-retrieval.md
@@ -1,0 +1,199 @@
+# ADR-005: Synaptic Memory Retrieval
+
+**Status:** Proposed
+
+**Date:** 2026-04-13
+
+**References:** [SynapticRAG (Hou et al., ACL 2025 Findings)](https://arxiv.org/abs/2410.13553v2)
+
+## Context
+
+Hrafn's memory retrieval pipeline (`src/memory/retrieval.rs`) operates in three
+stages: hot LRU cache, FTS5 keyword search, and vector similarity with hybrid
+merge. Time is treated only as a passive decay penalty (`src/memory/decay.rs`),
+and the knowledge graph (`src/memory/knowledge_graph.rs`) is not integrated into
+the recall path.
+
+This works well for direct lookups but degrades when the user references
+something from a prior conversation where the semantic signal alone is
+ambiguous. The system cannot follow temporal chains of reasoning: "we discussed
+X, which led to Y, which led to Z." It also cannot model how memories activate
+each other through co-occurrence patterns across sessions.
+
+SynapticRAG demonstrates that combining temporal association with
+biologically-inspired activation thresholds yields up to 14.66% improvement on
+conversational memory retrieval benchmarks (SMRCs, PerLTQA) over standard
+vector-similarity RAG.
+
+## Decision Drivers
+
+- Hrafn is a conversational agent where multi-turn, multi-session temporal
+  context matters.
+- The memory infrastructure is already 80% ready: embeddings, vector similarity,
+  knowledge graph with traversal, time-decay, importance scores, and a staged
+  retrieval pipeline with pluggable stages.
+- The knowledge graph exists but has no retrieval-time role.
+- Core memories are exempt from decay but have no mechanism to strengthen
+  retrieval of related non-core memories.
+
+## Proposed Changes
+
+### 1. Memory Access Tracking
+
+Record timestamps whenever a memory entry is stored or recalled. This produces
+an "access spike train" per entry: a time-series of access events that enables
+temporal association scoring.
+
+**Scope:** New `memory_access_log` table in the SQLite backend, populated by
+`store()` and `recall()` implementations.
+
+```sql
+CREATE TABLE memory_access_log (
+    memory_id TEXT NOT NULL,
+    accessed_at TEXT NOT NULL,  -- RFC 3339
+    access_type TEXT NOT NULL,  -- 'store' | 'recall'
+    FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_access_log_memory ON memory_access_log(memory_id);
+```
+
+**Risk:** Low. Additive schema change, no existing behavior modified.
+
+### 2. Temporal Association Scoring
+
+Augment `hybrid_merge` in `src/memory/vector.rs` with a temporal association
+signal. Given two candidate memories A and B, compute how often they were
+accessed near each other in time using a simplified DTW-inspired alignment:
+
+```
+T_score(A, B) = sigmoid(alignment_score(spike_train_A, spike_train_B))
+```
+
+The combined propagation score becomes:
+
+```
+P_score(A, B) = T_score(A, B) * cosine_similarity(A, B)
+```
+
+Integrate into hybrid merge as a third weighted signal:
+
+```
+final = w_vec * vector + w_kw * keyword + w_temp * temporal_association
+```
+
+Default weights: `w_vec = 0.5`, `w_kw = 0.3`, `w_temp = 0.2`. Configurable via
+`[memory]` settings to allow disabling (`w_temp = 0.0`) with no behavioral
+change.
+
+**Risk:** Medium. Changes retrieval scoring, but gated behind a weight that
+defaults conservatively and can be zeroed.
+
+### 3. Stimulus Propagation on the Knowledge Graph
+
+When a query activates a set of candidate memory nodes, propagate activation
+energy through the knowledge graph edges with decay:
+
+```
+S_child = S_parent * P_score(parent, child)
+```
+
+Nodes that accumulate sufficient stimulus from multiple convergent paths are
+included in the result set, even if they would not have been retrieved by direct
+similarity alone. This gives the knowledge graph a retrieval-time role.
+
+Propagation respects existing edge semantics:
+- `Extends` / `Uses`: full propagation weight.
+- `Replaces`: propagate only if the replacement is newer.
+- `AuthoredBy` / `AppliesTo`: reduced weight (0.3x) to avoid expert-node
+  fan-out dominating results.
+
+A configurable `stim_threshold` (default: 0.037, per the paper's optimized
+value) gates which nodes qualify for propagation.
+
+**Risk:** Medium-High. Introduces a new retrieval path through the knowledge
+graph. Should be feature-gated and opt-in initially.
+
+### 4. Leaky Integrate-and-Fire Memory Selection
+
+Replace the fixed `limit` parameter with a dynamic threshold mechanism inspired
+by the LIF neuron model:
+
+```
+tau * dV/dt = -V(t) + I(t)
+fire when V >= V_th
+```
+
+Where:
+- `V` is the membrane potential (accumulated retrieval confidence).
+- `I(t)` is the input current from retrieval scores.
+- `tau` is a dynamic time constant: frequently-accessed memories respond faster
+  (low tau), rarely-accessed memories need sustained stimulation (high tau).
+- `V_th` is the firing threshold (default: 0.099, per paper).
+
+This maps naturally onto existing Hrafn concepts:
+- `importance` score influences initial membrane potential.
+- `decay.rs` half-life maps to the leaky time constant.
+- `MemoryCategory::Core` (exempt from decay) acts as a permanently low
+  firing threshold.
+
+The `limit` parameter becomes a hard cap rather than the sole selection
+criterion.
+
+**Risk:** Medium. Changes how many memories are returned, but the hard cap
+preserves backward compatibility.
+
+## Implementation Plan
+
+| Phase | Scope | Risk | Depends On |
+|-------|-------|------|------------|
+| 1. Access tracking | New table + logging in SQLite backend | Low | -- |
+| 2. Temporal scoring | New scoring function + hybrid merge extension | Medium | Phase 1 |
+| 3. Graph propagation | New retrieval path, feature-gated | Medium-High | Phase 2 |
+| 4. LIF selection | Dynamic limit replacement | Medium | Phase 2 |
+
+Each phase is a separate PR. Phase 1 is prerequisite for all others. Phases 3
+and 4 are independent of each other.
+
+## Alternatives Considered
+
+### A. Ebbinghaus forgetting curve (MemoryBank approach)
+
+Already partially implemented via `decay.rs`. SynapticRAG subsumes this: the
+LIF time constant generalizes exponential decay with stimulus-driven
+reactivation. The existing decay module would remain for backward compatibility
+but become redundant once Phase 4 lands.
+
+### B. Recency-biased retrieval without temporal association
+
+Simpler: just boost recent memories. But this fails when the relevant memory is
+old but was temporally co-accessed with the current topic. SynapticRAG's DTW
+alignment captures this pattern; pure recency does not.
+
+### C. Full graph neural network for retrieval
+
+More powerful but far heavier: requires training, GPU inference, and a
+dependency on a GNN framework. SynapticRAG's analytical propagation model
+achieves strong results without learned parameters, fitting Hrafn's
+no-heavy-dependencies principle.
+
+## Consequences
+
+**Positive:**
+- Up to ~14% retrieval accuracy improvement on temporal conversational queries.
+- Knowledge graph gains a retrieval-time purpose, justifying its maintenance
+  cost.
+- Memory system becomes more biologically plausible, with natural concepts
+  (activation, decay, threshold) that are easier to reason about and tune.
+
+**Negative:**
+- Access logging adds write amplification to every store/recall operation.
+- Temporal scoring adds O(n^2) pairwise computation on candidate sets (mitigated
+  by the candidate pre-filter from FTS/vector stages).
+- Graph propagation adds latency proportional to graph density.
+- Four-phase rollout means the full benefit is not realized until all phases
+  land.
+
+**Neutral:**
+- Existing `decay.rs` remains functional throughout. No breaking changes to the
+  `Memory` trait.
+- Feature-gating phases 3-4 allows production use of phases 1-2 independently.

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -10043,6 +10043,11 @@ impl Config {
     /// Called after TOML deserialization and env-override application to catch
     /// obviously invalid values early instead of failing at arbitrary runtime points.
     pub fn validate(&self) -> Result<()> {
+        // Memory — access tracking requires audit
+        if self.memory.access_tracking_enabled && !self.memory.audit_enabled {
+            anyhow::bail!("memory.access_tracking_enabled requires memory.audit_enabled = true");
+        }
+
         // Tunnel — OpenVPN
         if self.tunnel.provider.trim() == "openvpn" {
             let openvpn = self.tunnel.openvpn.as_ref().ok_or_else(|| {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -5287,6 +5287,11 @@ pub struct MemoryConfig {
     /// Retention period for audit entries in days (default: 30).
     #[serde(default = "default_audit_retention_days")]
     pub audit_retention_days: u32,
+    /// Enable per-result access logging for synaptic retrieval (ADR-005 Phase 1).
+    /// Requires `audit_enabled = true`. Records which memory entries are returned
+    /// by each recall, producing spike trains for temporal association scoring.
+    #[serde(default)]
+    pub access_tracking_enabled: bool,
 
     // ── Policy Engine ───────────────────────────────────────────
     /// Memory policy configuration.
@@ -5429,6 +5434,7 @@ impl Default for MemoryConfig {
             conflict_threshold: default_conflict_threshold(),
             audit_enabled: false,
             audit_retention_days: default_audit_retention_days(),
+            access_tracking_enabled: false,
             policy: MemoryPolicyConfig::default(),
             sqlite_open_timeout_secs: None,
             qdrant: QdrantConfig::default(),

--- a/src/memory/audit.rs
+++ b/src/memory/audit.rs
@@ -131,8 +131,13 @@ impl<M: Memory> AuditedMemory<M> {
         // Batch-insert in a single transaction for performance.
         let _ = conn.execute_batch("BEGIN");
         for entry in results {
-            // Prefer the entry's own namespace; fall back to request-scoped namespace.
-            let namespace = request_namespace.unwrap_or(entry.namespace.as_str());
+            // Use the entry's own namespace (always populated, defaults to "default").
+            // Only fall back to request namespace if entry namespace is empty.
+            let namespace = if entry.namespace.is_empty() {
+                request_namespace.unwrap_or("default")
+            } else {
+                entry.namespace.as_str()
+            };
             let _ = conn.execute(
                 "INSERT INTO memory_access_log
                      (memory_id, memory_key, query, score, namespace, session_id, accessed_at)

--- a/src/memory/audit.rs
+++ b/src/memory/audit.rs
@@ -119,7 +119,7 @@ impl<M: Memory> AuditedMemory<M> {
     fn log_recall_results(
         &self,
         query: &str,
-        namespace: Option<&str>,
+        request_namespace: Option<&str>,
         session_id: Option<&str>,
         results: &[MemoryEntry],
     ) {
@@ -131,6 +131,8 @@ impl<M: Memory> AuditedMemory<M> {
         // Batch-insert in a single transaction for performance.
         let _ = conn.execute_batch("BEGIN");
         for entry in results {
+            // Prefer the entry's own namespace; fall back to request-scoped namespace.
+            let namespace = request_namespace.unwrap_or(entry.namespace.as_str());
             let _ = conn.execute(
                 "INSERT INTO memory_access_log
                      (memory_id, memory_key, query, score, namespace, session_id, accessed_at)
@@ -241,6 +243,8 @@ impl<M: Memory> AuditedMemory<M> {
              JOIN memory_access_log b
                ON a.memory_id = ?1
               AND b.memory_id != ?1
+              AND a.namespace IS b.namespace
+              AND a.session_id IS b.session_id
               AND ABS(
                   julianday(b.accessed_at) - julianday(a.accessed_at)
               ) * 86400 <= ?2

--- a/src/memory/audit.rs
+++ b/src/memory/audit.rs
@@ -42,10 +42,11 @@ pub struct AuditedMemory<M: Memory> {
     audit_conn: Arc<Mutex<Connection>>,
     #[allow(dead_code)]
     db_path: PathBuf,
+    access_tracking: bool,
 }
 
 impl<M: Memory> AuditedMemory<M> {
-    pub fn new(inner: M, workspace_dir: &Path) -> anyhow::Result<Self> {
+    pub fn new(inner: M, workspace_dir: &Path, access_tracking: bool) -> anyhow::Result<Self> {
         let db_path = workspace_dir.join("memory").join("audit.db");
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -65,13 +66,30 @@ impl<M: Memory> AuditedMemory<M> {
                  metadata TEXT
              );
              CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON memory_audit(timestamp);
-             CREATE INDEX IF NOT EXISTS idx_audit_operation ON memory_audit(operation);",
+             CREATE INDEX IF NOT EXISTS idx_audit_operation ON memory_audit(operation);
+             CREATE TABLE IF NOT EXISTS memory_access_log (
+                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                 memory_id   TEXT NOT NULL,
+                 memory_key  TEXT NOT NULL,
+                 query       TEXT NOT NULL,
+                 score       REAL,
+                 namespace   TEXT,
+                 session_id  TEXT,
+                 accessed_at TEXT NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS idx_access_log_memory_id
+                 ON memory_access_log(memory_id);
+             CREATE INDEX IF NOT EXISTS idx_access_log_accessed_at
+                 ON memory_access_log(accessed_at);
+             CREATE INDEX IF NOT EXISTS idx_access_log_memory_id_at
+                 ON memory_access_log(memory_id, accessed_at);",
         )?;
 
         Ok(Self {
             inner,
             audit_conn: Arc::new(Mutex::new(conn)),
             db_path,
+            access_tracking,
         })
     }
 
@@ -93,16 +111,58 @@ impl<M: Memory> AuditedMemory<M> {
         );
     }
 
+    /// Log per-result access entries for recall results.
+    ///
+    /// Each returned `MemoryEntry` gets a row in `memory_access_log`,
+    /// producing the "spike train" data needed for temporal association
+    /// scoring (ADR-005 Phase 2).
+    fn log_recall_results(
+        &self,
+        query: &str,
+        namespace: Option<&str>,
+        session_id: Option<&str>,
+        results: &[MemoryEntry],
+    ) {
+        if !self.access_tracking || results.is_empty() {
+            return;
+        }
+        let conn = self.audit_conn.lock();
+        let now = Local::now().to_rfc3339();
+        // Batch-insert in a single transaction for performance.
+        let _ = conn.execute_batch("BEGIN");
+        for entry in results {
+            let _ = conn.execute(
+                "INSERT INTO memory_access_log
+                     (memory_id, memory_key, query, score, namespace, session_id, accessed_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    entry.id,
+                    entry.key,
+                    query,
+                    entry.score,
+                    namespace,
+                    session_id,
+                    now
+                ],
+            );
+        }
+        let _ = conn.execute_batch("COMMIT");
+    }
+
     /// Prune audit entries older than the given number of days.
     pub fn prune_older_than(&self, retention_days: u32) -> anyhow::Result<u64> {
         let conn = self.audit_conn.lock();
         let cutoff =
             (Local::now() - chrono::Duration::days(i64::from(retention_days))).to_rfc3339();
-        let affected = conn.execute(
+        let audit_affected = conn.execute(
             "DELETE FROM memory_audit WHERE timestamp < ?1",
             params![cutoff],
         )?;
-        Ok(u64::try_from(affected).unwrap_or(0))
+        let access_affected = conn.execute(
+            "DELETE FROM memory_access_log WHERE accessed_at < ?1",
+            params![cutoff],
+        )?;
+        Ok(u64::try_from(audit_affected + access_affected).unwrap_or(0))
     }
 
     /// Count total audit entries.
@@ -112,6 +172,89 @@ impl<M: Memory> AuditedMemory<M> {
             conn.query_row("SELECT COUNT(*) FROM memory_audit", [], |row| row.get(0))?;
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         Ok(count as usize)
+    }
+
+    /// Count total access log entries.
+    pub fn access_log_count(&self) -> anyhow::Result<usize> {
+        let conn = self.audit_conn.lock();
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM memory_access_log", [], |row| {
+            row.get(0)
+        })?;
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        Ok(count as usize)
+    }
+
+    /// Return the access spike train for a given memory entry.
+    ///
+    /// Returns RFC 3339 timestamps in chronological order, optionally
+    /// filtered to entries on or after `since`.
+    pub fn get_access_spike_train(
+        &self,
+        memory_id: &str,
+        since: Option<&str>,
+    ) -> anyhow::Result<Vec<String>> {
+        let conn = self.audit_conn.lock();
+        let mut timestamps = Vec::new();
+        match since {
+            Some(cutoff) => {
+                let mut stmt = conn.prepare(
+                    "SELECT accessed_at FROM memory_access_log
+                     WHERE memory_id = ?1 AND accessed_at >= ?2
+                     ORDER BY accessed_at",
+                )?;
+                let rows = stmt.query_map(params![memory_id, cutoff], |row| row.get(0))?;
+                for row in rows {
+                    timestamps.push(row?);
+                }
+            }
+            None => {
+                let mut stmt = conn.prepare(
+                    "SELECT accessed_at FROM memory_access_log
+                     WHERE memory_id = ?1
+                     ORDER BY accessed_at",
+                )?;
+                let rows = stmt.query_map(params![memory_id], |row| row.get(0))?;
+                for row in rows {
+                    timestamps.push(row?);
+                }
+            }
+        }
+        Ok(timestamps)
+    }
+
+    /// Find memory IDs that were co-accessed with the given memory
+    /// within a time window.
+    ///
+    /// Returns `(other_memory_id, co_access_count)` pairs sorted by
+    /// count descending. Useful for discovering temporal associations.
+    pub fn get_coaccessed_memories(
+        &self,
+        memory_id: &str,
+        window_secs: i64,
+    ) -> anyhow::Result<Vec<(String, usize)>> {
+        let conn = self.audit_conn.lock();
+        // Find all memories that appear in access log entries within
+        // `window_secs` of any access to `memory_id`.
+        let mut stmt = conn.prepare(
+            "SELECT b.memory_id, COUNT(*) as cnt
+             FROM memory_access_log a
+             JOIN memory_access_log b
+               ON a.memory_id = ?1
+              AND b.memory_id != ?1
+              AND ABS(
+                  julianday(b.accessed_at) - julianday(a.accessed_at)
+              ) * 86400 <= ?2
+             GROUP BY b.memory_id
+             ORDER BY cnt DESC",
+        )?;
+        let rows = stmt.query_map(params![memory_id, window_secs], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, usize>(1)?))
+        })?;
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row?);
+        }
+        Ok(results)
     }
 }
 
@@ -147,9 +290,12 @@ impl<M: Memory> Memory for AuditedMemory<M> {
             session_id,
             Some(&format!("query={query}")),
         );
-        self.inner
+        let results = self
+            .inner
             .recall(query, limit, session_id, since, until)
-            .await
+            .await?;
+        self.log_recall_results(query, None, session_id, &results);
+        Ok(results)
     }
 
     async fn get(&self, key: &str) -> anyhow::Result<Option<MemoryEntry>> {
@@ -210,9 +356,12 @@ impl<M: Memory> Memory for AuditedMemory<M> {
             session_id,
             Some(&format!("query={query}")),
         );
-        self.inner
+        let results = self
+            .inner
             .recall_namespaced(namespace, query, limit, session_id, since, until)
-            .await
+            .await?;
+        self.log_recall_results(query, Some(namespace), session_id, &results);
+        Ok(results)
     }
 
     async fn store_with_metadata(
@@ -241,7 +390,7 @@ mod tests {
     async fn audited_memory_logs_store_operation() {
         let tmp = TempDir::new().unwrap();
         let inner = NoneMemory::new();
-        let audited = AuditedMemory::new(inner, tmp.path()).unwrap();
+        let audited = AuditedMemory::new(inner, tmp.path(), false).unwrap();
 
         audited
             .store("test_key", "test_value", MemoryCategory::Core, None)
@@ -255,7 +404,7 @@ mod tests {
     async fn audited_memory_logs_recall_operation() {
         let tmp = TempDir::new().unwrap();
         let inner = NoneMemory::new();
-        let audited = AuditedMemory::new(inner, tmp.path()).unwrap();
+        let audited = AuditedMemory::new(inner, tmp.path(), false).unwrap();
 
         let _ = audited.recall("query", 10, None, None, None).await;
 
@@ -266,7 +415,7 @@ mod tests {
     async fn audited_memory_prune_works() {
         let tmp = TempDir::new().unwrap();
         let inner = NoneMemory::new();
-        let audited = AuditedMemory::new(inner, tmp.path()).unwrap();
+        let audited = AuditedMemory::new(inner, tmp.path(), false).unwrap();
 
         audited
             .store("k1", "v1", MemoryCategory::Core, None)
@@ -284,10 +433,202 @@ mod tests {
     async fn audited_memory_delegates_correctly() {
         let tmp = TempDir::new().unwrap();
         let inner = NoneMemory::new();
-        let audited = AuditedMemory::new(inner, tmp.path()).unwrap();
+        let audited = AuditedMemory::new(inner, tmp.path(), false).unwrap();
 
         assert_eq!(audited.name(), "none");
         assert!(audited.health_check().await);
         assert_eq!(audited.count().await.unwrap(), 0);
+    }
+
+    // ── Access tracking tests ───────────────────────────────────
+
+    #[tokio::test]
+    async fn access_log_records_recall_results() {
+        let tmp = TempDir::new().unwrap();
+        let inner = NoneMemory::new();
+        let audited = AuditedMemory::new(inner, tmp.path(), true).unwrap();
+
+        // NoneMemory returns empty results, so manually log some
+        let entries = vec![
+            MemoryEntry {
+                id: "mem-1".into(),
+                key: "key-1".into(),
+                content: "hello".into(),
+                category: MemoryCategory::Core,
+                timestamp: "2026-01-01T00:00:00Z".into(),
+                session_id: None,
+                score: Some(0.9),
+                namespace: "default".into(),
+                importance: None,
+                superseded_by: None,
+            },
+            MemoryEntry {
+                id: "mem-2".into(),
+                key: "key-2".into(),
+                content: "world".into(),
+                category: MemoryCategory::Daily,
+                timestamp: "2026-01-01T00:00:00Z".into(),
+                session_id: None,
+                score: Some(0.7),
+                namespace: "default".into(),
+                importance: None,
+                superseded_by: None,
+            },
+        ];
+        audited.log_recall_results("test query", None, None, &entries);
+
+        assert_eq!(audited.access_log_count().unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn access_log_skipped_when_disabled() {
+        let tmp = TempDir::new().unwrap();
+        let inner = NoneMemory::new();
+        let audited = AuditedMemory::new(inner, tmp.path(), false).unwrap();
+
+        let entries = vec![MemoryEntry {
+            id: "mem-1".into(),
+            key: "key-1".into(),
+            content: "hello".into(),
+            category: MemoryCategory::Core,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            session_id: None,
+            score: Some(0.9),
+            namespace: "default".into(),
+            importance: None,
+            superseded_by: None,
+        }];
+        audited.log_recall_results("test query", None, None, &entries);
+
+        assert_eq!(audited.access_log_count().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn access_spike_train_returns_chronological_timestamps() {
+        let tmp = TempDir::new().unwrap();
+        let inner = NoneMemory::new();
+        let audited = AuditedMemory::new(inner, tmp.path(), true).unwrap();
+
+        let entry = vec![MemoryEntry {
+            id: "mem-1".into(),
+            key: "key-1".into(),
+            content: "hello".into(),
+            category: MemoryCategory::Core,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            session_id: None,
+            score: Some(0.9),
+            namespace: "default".into(),
+            importance: None,
+            superseded_by: None,
+        }];
+
+        // Log the same memory 3 times
+        audited.log_recall_results("q1", None, None, &entry);
+        audited.log_recall_results("q2", None, None, &entry);
+        audited.log_recall_results("q3", None, None, &entry);
+
+        let train = audited.get_access_spike_train("mem-1", None).unwrap();
+        assert_eq!(train.len(), 3);
+        // Timestamps should be in ascending order
+        for w in train.windows(2) {
+            assert!(w[0] <= w[1]);
+        }
+    }
+
+    #[tokio::test]
+    async fn access_log_pruning_removes_old_entries() {
+        let tmp = TempDir::new().unwrap();
+        let inner = NoneMemory::new();
+        let audited = AuditedMemory::new(inner, tmp.path(), true).unwrap();
+
+        let entries = vec![MemoryEntry {
+            id: "mem-1".into(),
+            key: "key-1".into(),
+            content: "hello".into(),
+            category: MemoryCategory::Core,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            session_id: None,
+            score: Some(0.9),
+            namespace: "default".into(),
+            importance: None,
+            superseded_by: None,
+        }];
+        audited.log_recall_results("q", None, None, &entries);
+
+        // Also create an audit entry
+        audited.log_audit(AuditOp::Store, Some("k"), None, None, None);
+
+        assert_eq!(audited.access_log_count().unwrap(), 1);
+        assert_eq!(audited.audit_count().unwrap(), 1);
+
+        // Prune with 0 retention removes everything
+        let pruned = audited.prune_older_than(0).unwrap();
+        assert!(pruned >= 2);
+        assert_eq!(audited.access_log_count().unwrap(), 0);
+        assert_eq!(audited.audit_count().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn coaccessed_memories_returns_co_occurring_ids() {
+        let tmp = TempDir::new().unwrap();
+        let inner = NoneMemory::new();
+        let audited = AuditedMemory::new(inner, tmp.path(), true).unwrap();
+
+        let together = vec![
+            MemoryEntry {
+                id: "A".into(),
+                key: "key-a".into(),
+                content: "a".into(),
+                category: MemoryCategory::Core,
+                timestamp: "2026-01-01T00:00:00Z".into(),
+                session_id: None,
+                score: Some(0.9),
+                namespace: "default".into(),
+                importance: None,
+                superseded_by: None,
+            },
+            MemoryEntry {
+                id: "B".into(),
+                key: "key-b".into(),
+                content: "b".into(),
+                category: MemoryCategory::Core,
+                timestamp: "2026-01-01T00:00:00Z".into(),
+                session_id: None,
+                score: Some(0.8),
+                namespace: "default".into(),
+                importance: None,
+                superseded_by: None,
+            },
+        ];
+
+        // A and B recalled together twice
+        audited.log_recall_results("q1", None, None, &together);
+        audited.log_recall_results("q2", None, None, &together);
+
+        // C recalled separately
+        let alone = vec![MemoryEntry {
+            id: "C".into(),
+            key: "key-c".into(),
+            content: "c".into(),
+            category: MemoryCategory::Core,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            session_id: None,
+            score: Some(0.5),
+            namespace: "default".into(),
+            importance: None,
+            superseded_by: None,
+        }];
+        audited.log_recall_results("q3", None, None, &alone);
+
+        // Co-accessed with A within 60 seconds should include B
+        let coaccessed = audited.get_coaccessed_memories("A", 60).unwrap();
+        assert!(!coaccessed.is_empty());
+        assert_eq!(coaccessed[0].0, "B");
+        // C should not appear (accessed at different time, not within window of A)
+        // Actually C could appear if the timestamps are very close (same test run),
+        // but B should have a higher count
+        if coaccessed.len() > 1 {
+            assert!(coaccessed[0].1 >= coaccessed[1].1);
+        }
     }
 }

--- a/src/memory/battle_tests.rs
+++ b/src/memory/battle_tests.rs
@@ -515,7 +515,7 @@ mod tests {
     async fn audit_logs_all_operation_types() {
         let tmp = TempDir::new().unwrap();
         let inner = crate::memory::NoneMemory::new();
-        let audited = AuditedMemory::new(inner, tmp.path()).unwrap();
+        let audited = AuditedMemory::new(inner, tmp.path(), false).unwrap();
 
         audited
             .store("k1", "v1", MemoryCategory::Core, None)
@@ -537,7 +537,7 @@ mod tests {
     async fn audit_with_namespaced_operations() {
         let tmp = TempDir::new().unwrap();
         let inner = crate::memory::NoneMemory::new();
-        let audited = AuditedMemory::new(inner, tmp.path()).unwrap();
+        let audited = AuditedMemory::new(inner, tmp.path(), false).unwrap();
 
         audited
             .store_with_metadata(
@@ -562,7 +562,7 @@ mod tests {
     async fn audit_wrapping_sqlite_backend() {
         let tmp = TempDir::new().unwrap();
         let inner = SqliteMemory::new(tmp.path()).unwrap();
-        let audited = AuditedMemory::new(inner, tmp.path()).unwrap();
+        let audited = AuditedMemory::new(inner, tmp.path(), false).unwrap();
 
         // Full round-trip through audited sqlite
         audited
@@ -584,7 +584,7 @@ mod tests {
     async fn audit_concurrent_operations() {
         let tmp = TempDir::new().unwrap();
         let inner = crate::memory::NoneMemory::new();
-        let audited = Arc::new(AuditedMemory::new(inner, tmp.path()).unwrap());
+        let audited = Arc::new(AuditedMemory::new(inner, tmp.path(), false).unwrap());
 
         let mut handles = Vec::new();
         for i in 0..10 {
@@ -774,7 +774,7 @@ mod tests {
     async fn pipeline_with_audited_sqlite() {
         let tmp = TempDir::new().unwrap();
         let sqlite = SqliteMemory::new(tmp.path()).unwrap();
-        let audited = AuditedMemory::new(sqlite, tmp.path()).unwrap();
+        let audited = AuditedMemory::new(sqlite, tmp.path(), false).unwrap();
         let audited = Arc::new(audited);
 
         // Store through audited backend

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -27,7 +27,6 @@ pub mod vector;
 #[cfg(test)]
 mod battle_tests;
 
-#[allow(unused_imports)]
 pub use audit::AuditedMemory;
 #[allow(unused_imports)]
 pub use backend::{
@@ -56,33 +55,59 @@ use anyhow::Context;
 use std::path::Path;
 use std::sync::Arc;
 
+/// Conditionally wrap a concrete memory backend with audit logging.
+fn maybe_wrap_audit<M: Memory + 'static>(
+    backend: M,
+    audit_enabled: bool,
+    access_tracking: bool,
+    workspace_dir: &Path,
+) -> anyhow::Result<Box<dyn Memory>> {
+    if audit_enabled {
+        Ok(Box::new(AuditedMemory::new(
+            backend,
+            workspace_dir,
+            access_tracking,
+        )?))
+    } else {
+        Ok(Box::new(backend))
+    }
+}
+
 fn create_memory_with_builders<F>(
     backend_name: &str,
     workspace_dir: &Path,
     mut sqlite_builder: F,
     unknown_context: &str,
+    audit_enabled: bool,
+    access_tracking: bool,
 ) -> anyhow::Result<Box<dyn Memory>>
 where
     F: FnMut() -> anyhow::Result<SqliteMemory>,
 {
     match classify_memory_backend(backend_name) {
-        MemoryBackendKind::Sqlite => Ok(Box::new(sqlite_builder()?)),
+        MemoryBackendKind::Sqlite => {
+            let mem = sqlite_builder()?;
+            maybe_wrap_audit(mem, audit_enabled, access_tracking, workspace_dir)
+        }
         MemoryBackendKind::Lucid => {
             let local = sqlite_builder()?;
-            Ok(Box::new(LucidMemory::new(workspace_dir, local)))
+            let lucid = LucidMemory::new(workspace_dir, local);
+            maybe_wrap_audit(lucid, audit_enabled, access_tracking, workspace_dir)
         }
         MemoryBackendKind::Muninndb | MemoryBackendKind::Qdrant | MemoryBackendKind::Markdown => {
             // Offline/lightweight fallback — data stored here is separate from
             // the actual backend (MuninnDB/Qdrant) and won't be visible there.
             tracing::debug!("Using markdown fallback for '{backend_name}' in lightweight context");
-            Ok(Box::new(MarkdownMemory::new(workspace_dir)))
+            let mem = MarkdownMemory::new(workspace_dir);
+            maybe_wrap_audit(mem, audit_enabled, access_tracking, workspace_dir)
         }
         MemoryBackendKind::None => Ok(Box::new(NoneMemory::new())),
         MemoryBackendKind::Unknown => {
             tracing::warn!(
                 "Unknown memory backend '{backend_name}'{unknown_context}, falling back to markdown"
             );
-            Ok(Box::new(MarkdownMemory::new(workspace_dir)))
+            let mem = MarkdownMemory::new(workspace_dir);
+            maybe_wrap_audit(mem, audit_enabled, access_tracking, workspace_dir)
         }
     }
 }
@@ -353,11 +378,12 @@ pub fn create_memory_with_storage_and_routes(
                 url,
                 vault
             );
-            return Ok(Box::new(MuninndbMemory::new(
-                &url,
-                &vault,
-                muninndb_api_key,
-            )));
+            return maybe_wrap_audit(
+                MuninndbMemory::new(&url, &vault, muninndb_api_key),
+                config.audit_enabled,
+                config.access_tracking_enabled,
+                workspace_dir,
+            );
         }
         #[cfg(not(feature = "memory-muninndb"))]
         {
@@ -365,11 +391,13 @@ pub fn create_memory_with_storage_and_routes(
                 "MuninnDB backend is configured but this build was compiled without \
                  the `memory-muninndb` feature; falling back to SQLite."
             );
-            return Ok(Box::new(build_sqlite_memory(
-                config,
+            let mem = build_sqlite_memory(config, workspace_dir, &resolved_embedding)?;
+            return maybe_wrap_audit(
+                mem,
+                config.audit_enabled,
+                config.access_tracking_enabled,
                 workspace_dir,
-                &resolved_embedding,
-            )?));
+            );
         }
     }
 
@@ -406,12 +434,12 @@ pub fn create_memory_with_storage_and_routes(
             url,
             collection
         );
-        return Ok(Box::new(QdrantMemory::new_lazy(
-            &url,
-            &collection,
-            qdrant_api_key,
-            embedder,
-        )));
+        return maybe_wrap_audit(
+            QdrantMemory::new_lazy(&url, &collection, qdrant_api_key, embedder),
+            config.audit_enabled,
+            config.access_tracking_enabled,
+            workspace_dir,
+        );
     }
 
     create_memory_with_builders(
@@ -419,6 +447,8 @@ pub fn create_memory_with_storage_and_routes(
         workspace_dir,
         || build_sqlite_memory(config, workspace_dir, &resolved_embedding),
         "",
+        config.audit_enabled,
+        config.access_tracking_enabled,
     )
 }
 
@@ -437,6 +467,8 @@ pub fn create_memory_for_migration(
         workspace_dir,
         || SqliteMemory::new(workspace_dir),
         " during migration",
+        false,
+        false,
     )
 }
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -101,7 +101,10 @@ where
             let mem = MarkdownMemory::new(workspace_dir);
             maybe_wrap_audit(mem, audit_enabled, access_tracking, workspace_dir)
         }
-        MemoryBackendKind::None => Ok(Box::new(NoneMemory::new())),
+        MemoryBackendKind::None => {
+            let mem = NoneMemory::new();
+            maybe_wrap_audit(mem, audit_enabled, access_tracking, workspace_dir)
+        }
         MemoryBackendKind::Unknown => {
             tracing::warn!(
                 "Unknown memory backend '{backend_name}'{unknown_context}, falling back to markdown"

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -65,13 +65,17 @@ impl RetrievalPipeline {
         limit: usize,
         session_id: Option<&str>,
         namespace: Option<&str>,
+        since: Option<&str>,
+        until: Option<&str>,
     ) -> String {
         format!(
-            "{}:{}:{}:{}",
+            "{}:{}:{}:{}:{}:{}",
             query,
             limit,
             session_id.unwrap_or(""),
-            namespace.unwrap_or("")
+            namespace.unwrap_or(""),
+            since.unwrap_or(""),
+            until.unwrap_or("")
         )
     }
 
@@ -120,7 +124,7 @@ impl RetrievalPipeline {
         since: Option<&str>,
         until: Option<&str>,
     ) -> anyhow::Result<Vec<MemoryEntry>> {
-        let ck = Self::cache_key(query, limit, session_id, namespace);
+        let ck = Self::cache_key(query, limit, session_id, namespace, since, until);
 
         for stage in &self.config.stages {
             match stage.as_str() {
@@ -206,7 +210,7 @@ mod tests {
         let pipeline = RetrievalPipeline::new(memory, RetrievalConfig::default());
 
         // Force a cache entry
-        let ck = RetrievalPipeline::cache_key("test", 10, None, None);
+        let ck = RetrievalPipeline::cache_key("test", 10, None, None, None, None);
         pipeline.store_in_cache(ck, vec![]);
 
         assert_eq!(pipeline.cache_size(), 1);
@@ -216,12 +220,31 @@ mod tests {
 
     #[test]
     fn cache_key_includes_all_params() {
-        let k1 = RetrievalPipeline::cache_key("hello", 10, Some("sess-a"), Some("ns1"));
-        let k2 = RetrievalPipeline::cache_key("hello", 10, Some("sess-b"), Some("ns1"));
-        let k3 = RetrievalPipeline::cache_key("hello", 10, Some("sess-a"), Some("ns2"));
+        let k1 = RetrievalPipeline::cache_key("hello", 10, Some("sess-a"), Some("ns1"), None, None);
+        let k2 = RetrievalPipeline::cache_key("hello", 10, Some("sess-b"), Some("ns1"), None, None);
+        let k3 = RetrievalPipeline::cache_key("hello", 10, Some("sess-a"), Some("ns2"), None, None);
 
         assert_ne!(k1, k2);
         assert_ne!(k1, k3);
+    }
+
+    #[test]
+    fn cache_key_includes_time_params() {
+        let k1 = RetrievalPipeline::cache_key("q", 10, None, None, None, None);
+        let k2 = RetrievalPipeline::cache_key("q", 10, None, None, Some("2026-01-01"), None);
+        let k3 = RetrievalPipeline::cache_key("q", 10, None, None, None, Some("2026-12-31"));
+        let k4 = RetrievalPipeline::cache_key(
+            "q",
+            10,
+            None,
+            None,
+            Some("2026-01-01"),
+            Some("2026-12-31"),
+        );
+
+        assert_ne!(k1, k2);
+        assert_ne!(k1, k3);
+        assert_ne!(k2, k4);
     }
 
     #[tokio::test]
@@ -241,7 +264,7 @@ mod tests {
         assert!(results.is_empty());
 
         // Manually insert a cache entry
-        let ck = RetrievalPipeline::cache_key("cached_query", 5, None, None);
+        let ck = RetrievalPipeline::cache_key("cached_query", 5, None, None, None, None);
         let fake_entry = MemoryEntry {
             id: "1".into(),
             key: "k".into(),

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -59,7 +59,11 @@ impl RetrievalPipeline {
         }
     }
 
-    /// Build a cache key from query parameters.
+    /// Build a collision-safe cache key from query parameters.
+    ///
+    /// Uses length-prefixed encoding to prevent ambiguous splits
+    /// (e.g. `session_id="a:b"` vs `namespace="a:b"`) and explicit
+    /// `N` sentinels for `None` vs `Some("")`.
     fn cache_key(
         query: &str,
         limit: usize,
@@ -68,14 +72,22 @@ impl RetrievalPipeline {
         since: Option<&str>,
         until: Option<&str>,
     ) -> String {
+        fn enc(v: &str) -> String {
+            format!("{}:{v}", v.len())
+        }
+        fn enc_opt(v: Option<&str>) -> String {
+            match v {
+                Some(s) => format!("S{}:{s}", s.len()),
+                None => "N".to_string(),
+            }
+        }
         format!(
-            "{}:{}:{}:{}:{}:{}",
-            query,
-            limit,
-            session_id.unwrap_or(""),
-            namespace.unwrap_or(""),
-            since.unwrap_or(""),
-            until.unwrap_or("")
+            "q{}|l{limit}|sid{}|ns{}|since{}|until{}",
+            enc(query),
+            enc_opt(session_id),
+            enc_opt(namespace),
+            enc_opt(since),
+            enc_opt(until),
         )
     }
 

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -445,6 +445,7 @@ fn memory_config_defaults_for_backend(backend: &str) -> MemoryConfig {
         conflict_threshold: 0.85,
         audit_enabled: false,
         audit_retention_days: 30,
+        access_tracking_enabled: false,
         policy: crate::config::MemoryPolicyConfig::default(),
         sqlite_open_timeout_secs: None,
         qdrant: crate::config::QdrantConfig::default(),


### PR DESCRIPTION
Closes #197

## Summary

Implements Phase 1 of ADR-005 (Synaptic Memory Retrieval), laying the data-collection groundwork for temporal association scoring in later phases.

- **Fix cache_key bug**: `RetrievalPipeline::cache_key()` now uses collision-safe length-prefixed encoding and includes `since`/`until` time-range parameters
- **Add `memory_access_log` table**: Records which specific memory entries are returned by each recall, producing per-memory "spike trains" for Phase 2 temporal scoring
- **Wire `AuditedMemory` into memory factory**: All memory backends are now conditionally wrapped with audit logging when `audit_enabled` is set
- **Fix ADR-005 factual errors**: Corrected weight defaults (0.7/0.3, not 0.5/0.3), call site list, and added context about existing audit infrastructure

## Key changes

| File | Change |
|------|--------|
| `docs/architecture/adr-005-synaptic-memory-retrieval.md` | Fix factual errors in the ADR |
| `src/memory/retrieval.rs` | Collision-safe cache key with `since`/`until` |
| `src/config/schema.rs` | Add `access_tracking_enabled` config + validation |
| `src/memory/audit.rs` | Access log table, spike train + co-access query APIs |
| `src/memory/mod.rs` | Wire `AuditedMemory` into factory via `maybe_wrap_audit()` |
| `src/onboard/wizard.rs` | Add new config field to wizard defaults |
| `src/memory/battle_tests.rs` | Update call sites for new constructor param |

## Design decisions

- **New table in existing `audit.db`** rather than a separate database — the existing `memory_audit` table tracks operation-level events but not per-result data needed for spike trains
- **Double-gated opt-in**: requires both `audit_enabled = true` AND `access_tracking_enabled = true`
- **Wraps concrete types before boxing** via `maybe_wrap_audit()` helper, avoiding the need for `impl Memory for Box<dyn Memory>`
- **Entry namespace preferred** over request namespace in access log for accurate per-entry metadata
- **Co-access scoped** to same namespace/session to prevent false temporal associations

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all tests passed
- [x] 5 new access tracking unit tests (recording, disable gate, spike train, pruning, co-access)
- [x] 1 new cache key test for time params
- [x] All battle tests pass with updated constructor

https://claude.ai/code/session_01XpVcqwPDSLcnefFqrJBJdN