### PR TITLE
feat(a2a): GetExtendedAgentCard + multi-tenancy

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -3906,6 +3906,19 @@ pub struct A2aConfig {
     /// Capability tags advertised in the agent card skills list.
     #[serde(default)]
     pub capabilities: Vec<String>,
+    /// Extended capability tags advertised only in the authenticated
+    /// `GET /extendedAgentCard` response.  The public agent card
+    /// (`/.well-known/agent-card.json`) continues to advertise only
+    /// `capabilities`.  Empty by default — when non-empty, the public
+    /// card advertises `capabilities.extendedAgentCard = true`.
+    #[serde(default)]
+    pub extended_skills: Vec<String>,
+    /// Default tenant string advertised on each `AgentInterface` entry in
+    /// the agent card.  Opaque — any caller may override per-request via
+    /// the `tenant` field on A2A messages.  When unset, no `tenant` field
+    /// appears on the interface entries.
+    #[serde(default)]
+    pub default_tenant: Option<String>,
     /// Telegram chat ID for A2A activity notifications (e.g. a group chat).
     /// When set, inbound A2A task results are also posted to this chat.
     #[serde(default)]
@@ -3934,6 +3947,8 @@ impl std::fmt::Debug for A2aConfig {
             .field("protocol_version", &self.protocol_version)
             .field("provider_url", &self.provider_url)
             .field("capabilities", &self.capabilities)
+            .field("extended_skills", &self.extended_skills)
+            .field("default_tenant", &self.default_tenant)
             .field("notify_chat_id", &self.notify_chat_id)
             .field("body_limit_bytes", &self.body_limit_bytes)
             .field("task_ttl_secs", &self.task_ttl_secs)
@@ -3954,6 +3969,8 @@ impl Default for A2aConfig {
             protocol_version: None,
             provider_url: None,
             capabilities: Vec::new(),
+            extended_skills: Vec::new(),
+            default_tenant: None,
             notify_chat_id: None,
             body_limit_bytes: default_a2a_body_limit(),
             task_ttl_secs: default_a2a_task_ttl(),

--- a/src/gateway/a2a.rs
+++ b/src/gateway/a2a.rs
@@ -394,8 +394,35 @@ pub struct TaskArtifactUpdateEvent {
 
 // ── Agent card generation ────────────────────────────────────────
 
+/// Scope of an A2A agent card — public (unauthenticated) or extended
+/// (returned from the authenticated `/extendedAgentCard` endpoint, which
+/// additionally advertises skills listed in `A2aConfig.extended_skills`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CardScope {
+    /// Public card served at `/.well-known/agent-card.json`.
+    Public,
+    /// Extended card served at `/extendedAgentCard` — requires auth.
+    Extended,
+}
+
+/// Build a single `AgentSkill` JSON object from a capability tag.
+fn skill_from_tag(tag: &str) -> serde_json::Value {
+    json!({
+        "id": tag,
+        "name": tag,
+        "description": format!("{tag} capability"),
+        "tags": [tag],
+        "examples": []
+    })
+}
+
 /// Generate the A2A agent card from configuration.
-pub fn generate_agent_card(config: &crate::config::Config) -> serde_json::Value {
+///
+/// The public endpoint (`/.well-known/agent-card.json`) passes
+/// [`CardScope::Public`]; the authenticated `/extendedAgentCard` endpoint
+/// passes [`CardScope::Extended`] which appends any
+/// `A2aConfig.extended_skills` to the skill list.
+pub fn generate_agent_card(config: &crate::config::Config, scope: CardScope) -> serde_json::Value {
     let a2a = &config.a2a;
 
     let name = a2a
@@ -418,7 +445,9 @@ pub fn generate_agent_card(config: &crate::config::Config) -> serde_json::Value 
         .clone()
         .unwrap_or_else(|| format!("http://{}:{}", config.gateway.host, config.gateway.port));
 
-    let skills: Vec<serde_json::Value> = if a2a.capabilities.is_empty() {
+    // Public skills always appear.  Extended skills (if any) are appended
+    // only when the caller is authenticated (scope == Extended).
+    let mut skills: Vec<serde_json::Value> = if a2a.capabilities.is_empty() {
         vec![json!({
             "id": "general",
             "name": "General",
@@ -427,19 +456,11 @@ pub fn generate_agent_card(config: &crate::config::Config) -> serde_json::Value 
             "examples": ["Help me with a task"]
         })]
     } else {
-        a2a.capabilities
-            .iter()
-            .map(|c| {
-                json!({
-                    "id": c,
-                    "name": c,
-                    "description": format!("{c} capability"),
-                    "tags": [c],
-                    "examples": []
-                })
-            })
-            .collect()
+        a2a.capabilities.iter().map(|c| skill_from_tag(c)).collect()
     };
+    if scope == CardScope::Extended {
+        skills.extend(a2a.extended_skills.iter().map(|c| skill_from_tag(c)));
+    }
 
     let protocol_version = a2a
         .protocol_version
@@ -455,19 +476,39 @@ pub fn generate_agent_card(config: &crate::config::Config) -> serde_json::Value 
     let requires_auth =
         a2a.bearer_token.as_ref().is_some_and(|t| !t.is_empty()) || config.gateway.require_pairing;
 
+    // Build the (single) AgentInterface entry, optionally tagged with the
+    // configured default tenant.
+    let mut interface = json!({
+        "url": format!("{base_url}/"),
+        "protocol_binding": "JSONRPC",
+        "protocol_version": protocol_version
+    });
+    if let Some(ref tenant) = a2a.default_tenant {
+        interface["tenant"] = json!(tenant);
+    }
+
+    // Advertise the extended-card capability when any extended skill is
+    // configured — otherwise omit (treat as false per v1.0).
+    let has_extended = !a2a.extended_skills.is_empty();
+    let capabilities_obj = if has_extended {
+        json!({
+            "streaming": true,
+            "pushNotifications": false,
+            "extendedAgentCard": true
+        })
+    } else {
+        json!({
+            "streaming": true,
+            "pushNotifications": false
+        })
+    };
+
     let mut card = json!({
         "name": name,
         "description": description,
         "version": version,
-        "supported_interfaces": [{
-            "url": format!("{base_url}/"),
-            "protocol_binding": "JSONRPC",
-            "protocol_version": protocol_version
-        }],
-        "capabilities": {
-            "streaming": true,
-            "pushNotifications": false
-        },
+        "supported_interfaces": [interface],
+        "capabilities": capabilities_obj,
         "defaultInputModes": ["text/plain"],
         "defaultOutputModes": ["text/plain"],
         "skills": skills,
@@ -507,6 +548,36 @@ pub async fn handle_agent_card(State(state): State<AppState>) -> impl IntoRespon
         )
             .into_response(),
     }
+}
+
+/// `GET /extendedAgentCard` — authenticated discovery endpoint that
+/// returns the full agent card, including skills gated behind
+/// `A2aConfig.extended_skills`.  The public card at
+/// `/.well-known/agent-card.json` continues to advertise only the
+/// unauthenticated skill set.
+pub async fn handle_extended_agent_card(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    // Feature gate — same check as the public card.
+    if state.a2a_agent_card.is_none() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "A2A protocol not enabled"})),
+        )
+            .into_response();
+    }
+
+    // Authentication required for the extended card.
+    if let Err(resp) = require_a2a_auth(&state, &headers) {
+        return resp.into_response();
+    }
+
+    // Generate the extended card fresh from current config so that
+    // extended_skills changes take effect without a server restart.
+    let config = state.config.lock().clone();
+    let card = generate_agent_card(&config, CardScope::Extended);
+    (StatusCode::OK, Json(card)).into_response()
 }
 
 /// `POST /a2a` — authenticated JSON-RPC 2.0 task endpoint.
@@ -2180,7 +2251,7 @@ mod tests {
             config.a2a.bearer_token = Some(token.to_string());
         }
 
-        let card = generate_agent_card(&config);
+        let card = generate_agent_card(&config, CardScope::Public);
 
         AppState {
             config: Arc::new(Mutex::new(config)),
@@ -2253,7 +2324,7 @@ mod tests {
             ..Default::default()
         };
 
-        let card = generate_agent_card(&config);
+        let card = generate_agent_card(&config, CardScope::Public);
         assert_eq!(card["name"], "ZeroClaw Agent");
         // v1.0: supported_interfaces replaces top-level url
         let ifaces = card["supported_interfaces"].as_array().unwrap();
@@ -2293,7 +2364,7 @@ mod tests {
             ..Default::default()
         };
 
-        let card = generate_agent_card(&config);
+        let card = generate_agent_card(&config, CardScope::Public);
         assert_eq!(card["name"], "my-agent");
         assert_eq!(card["description"], "My custom agent");
         // v1.0: URL is in supported_interfaces
@@ -2467,6 +2538,112 @@ mod tests {
         state.a2a_agent_card = None;
         let resp = handle_agent_card(State(state)).await.into_response();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ── Extended agent card tests ────────────────────────────
+
+    fn state_with_extended_skills(bearer: Option<&str>, extended: &[&str]) -> AppState {
+        let state = a2a_test_state(bearer, false, &[]);
+        {
+            let mut cfg = state.config.lock();
+            cfg.a2a.extended_skills = extended.iter().map(|s| (*s).to_string()).collect();
+        }
+        state
+    }
+
+    #[tokio::test]
+    async fn extended_agent_card_requires_auth_when_token_configured() {
+        let state = state_with_extended_skills(Some("secret"), &["admin", "billing"]);
+        let resp = handle_extended_agent_card(State(state), HeaderMap::new())
+            .await
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn extended_agent_card_returns_extended_skills_when_authenticated() {
+        let state = state_with_extended_skills(Some("secret"), &["admin", "billing"]);
+        let resp = handle_extended_agent_card(State(state), bearer_header("secret"))
+            .await
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = response_json(resp).await;
+        let skill_ids: Vec<&str> = body["skills"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|s| s["id"].as_str())
+            .collect();
+        assert!(skill_ids.contains(&"admin"));
+        assert!(skill_ids.contains(&"billing"));
+    }
+
+    #[tokio::test]
+    async fn public_card_omits_extended_skills() {
+        let state = state_with_extended_skills(Some("secret"), &["admin", "billing"]);
+        // Re-generate the cached public card from updated config so the
+        // test fixture reflects the post-init extended_skills value.
+        {
+            let config = state.config.lock().clone();
+            let card = generate_agent_card(&config, CardScope::Public);
+            // Mutate via raw pointer isn't safe — rebuild the AppState with
+            // a fresh Arc.  Easier: just call generate_agent_card directly
+            // below.
+            let _ = card;
+        }
+        let config = state.config.lock().clone();
+        let public = generate_agent_card(&config, CardScope::Public);
+        let skill_ids: Vec<&str> = public["skills"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|s| s["id"].as_str())
+            .collect();
+        assert!(!skill_ids.contains(&"admin"));
+        assert!(!skill_ids.contains(&"billing"));
+    }
+
+    #[test]
+    fn public_card_advertises_extended_capability_when_extended_skills_present() {
+        let config = crate::config::Config {
+            a2a: crate::config::A2aConfig {
+                enabled: true,
+                extended_skills: vec!["admin".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let card = generate_agent_card(&config, CardScope::Public);
+        assert_eq!(card["capabilities"]["extendedAgentCard"], true);
+    }
+
+    #[test]
+    fn public_card_omits_extended_capability_when_no_extended_skills() {
+        let config = crate::config::Config {
+            a2a: crate::config::A2aConfig {
+                enabled: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let card = generate_agent_card(&config, CardScope::Public);
+        // Field is absent when no extended skills are configured.
+        assert!(card["capabilities"].get("extendedAgentCard").is_none());
+    }
+
+    #[test]
+    fn agent_card_includes_default_tenant_on_interface() {
+        let config = crate::config::Config {
+            a2a: crate::config::A2aConfig {
+                enabled: true,
+                default_tenant: Some("acme".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let card = generate_agent_card(&config, CardScope::Public);
+        let ifaces = card["supported_interfaces"].as_array().unwrap();
+        assert_eq!(ifaces[0]["tenant"], "acme");
     }
 
     #[tokio::test]

--- a/src/gateway/a2a.rs
+++ b/src/gateway/a2a.rs
@@ -273,6 +273,22 @@ pub struct Task {
     pub history: Option<Vec<Message>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
+    /// Opaque tenant scope for this task (A2A v1.0 multi-tenancy).
+    /// `None` or empty means the "default" tenant.  Tenant is metadata
+    /// only — Hrafn does NOT enforce tenant-based authorization here;
+    /// any authenticated caller may use any tenant string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+}
+
+/// Return true when a stored task's tenant matches the requested tenant.
+/// Both `None` and `Some("")` are treated as the "default" tenant, so
+/// tasks created via unscoped routes remain reachable through the
+/// unscoped routes (and vice versa) while being invisible to any
+/// non-default tenant scope.
+fn tenant_matches(stored: Option<&str>, requested: &str) -> bool {
+    let stored = stored.unwrap_or("");
+    stored == requested
 }
 
 /// A2A v1.0 task state enum — SCREAMING_SNAKE_CASE with `TASK_STATE_` prefix.
@@ -715,6 +731,15 @@ async fn handle_message_send(
         }
     };
 
+    // A2A v1.0 multi-tenancy: read the opaque tenant string from the top
+    // level of the params envelope.  Empty string == default tenant.
+    let tenant = req
+        .params
+        .get("tenant")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
     // Check for return_immediately flag in configuration.
     let return_immediately = req
         .params
@@ -762,6 +787,11 @@ async fn handle_message_send(
                 artifacts: None,
                 history: Some(vec![inbound_msg.clone()]),
                 metadata: None,
+                tenant: if tenant.is_empty() {
+                    None
+                } else {
+                    Some(tenant.clone())
+                },
             },
         );
     }
@@ -778,6 +808,14 @@ async fn handle_message_send(
         let ctx = context_id.clone();
         let bg_prompt = prompt_text.clone();
         let bg_session = format!("a2a-ctx-{}", &context_id);
+        // Preserve tenant scope on the background-finalized task so that
+        // tenant-scoped `tasks/get` lookups keep working after the agent
+        // pipeline completes asynchronously.
+        let bg_tenant = if tenant.is_empty() {
+            None
+        } else {
+            Some(tenant.clone())
+        };
         let telegram_notify = config.a2a.notify_chat_id.and_then(|chat_id| {
             config
                 .channels_config
@@ -836,6 +874,7 @@ async fn handle_message_send(
                         artifacts: Some(vec![artifact]),
                         history: Some(vec![inbound_msg]),
                         metadata: None,
+                        tenant: bg_tenant.clone(),
                     };
                     let mut tasks = bg_store.tasks.write().await;
                     if !tasks
@@ -870,6 +909,7 @@ async fn handle_message_send(
                         artifacts: None,
                         history: Some(vec![inbound_msg]),
                         metadata: None,
+                        tenant: bg_tenant.clone(),
                     };
                     let mut tasks = bg_store.tasks.write().await;
                     if !tasks
@@ -958,6 +998,11 @@ async fn handle_message_send(
                 artifacts: Some(vec![artifact]),
                 history: Some(vec![inbound_msg]),
                 metadata: None,
+                tenant: if tenant.is_empty() {
+                    None
+                } else {
+                    Some(tenant.clone())
+                },
             };
 
             // Only write the result if the task hasn't been canceled in the
@@ -1012,6 +1057,11 @@ async fn handle_message_send(
                 artifacts: None,
                 history: Some(vec![inbound_msg]),
                 metadata: None,
+                tenant: if tenant.is_empty() {
+                    None
+                } else {
+                    Some(tenant.clone())
+                },
             };
 
             // Preserve Canceled state — don't overwrite with Failed.
@@ -1060,9 +1110,18 @@ async fn handle_tasks_get(
         );
     }
 
+    // Tenant scope: a task created under tenant A must 404 when fetched
+    // under tenant B.  Empty tenant == default tenant; unscoped routes
+    // pass "" which only matches tasks with None/"" tenant.
+    let tenant = req
+        .params
+        .get("tenant")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
     let tasks = task_store.tasks.read().await;
     match tasks.get(task_id) {
-        Some(task) => (
+        Some(task) if tenant_matches(task.tenant.as_deref(), tenant) => (
             StatusCode::OK,
             Json(json!({
                 "jsonrpc": "2.0",
@@ -1070,7 +1129,7 @@ async fn handle_tasks_get(
                 "result": task
             })),
         ),
-        None => (
+        _ => (
             StatusCode::OK,
             Json(rpc_error(
                 req.id,
@@ -1100,9 +1159,18 @@ async fn handle_tasks_cancel(
         );
     }
 
+    // Tenant scope: tasks created under tenant A must not be cancelable
+    // from tenant B — the result is TASK_NOT_FOUND.
+    let tenant = req
+        .params
+        .get("tenant")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
     let result = {
         let mut tasks = task_store.tasks.write().await;
         match tasks.get_mut(task_id) {
+            Some(task) if !tenant_matches(task.tenant.as_deref(), tenant) => None,
             Some(task) => {
                 if task.status.state.is_terminal() {
                     return (
@@ -1202,6 +1270,15 @@ async fn handle_tasks_list(
         .and_then(|v| v.as_str())
         .map(String::from);
 
+    // Tenant scope: the unscoped `tasks/list` route only sees
+    // default-tenant tasks; a tenant-scoped route sees only that tenant's.
+    let tenant = req
+        .params
+        .get("tenant")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
     let tasks = task_store.tasks.read().await;
 
     // Collect and sort by task ID for stable ordering
@@ -1212,6 +1289,9 @@ async fn handle_tasks_list(
     let filtered: Vec<&Task> = sorted
         .into_iter()
         .filter(|t| {
+            if !tenant_matches(t.tenant.as_deref(), &tenant) {
+                return false;
+            }
             if let Some(ref ctx) = context_id_filter {
                 if t.context_id.as_deref() != Some(ctx) {
                     return false;
@@ -1325,7 +1405,18 @@ async fn handle_tasks_get_by_context(
         );
     }
 
-    let tasks = task_store.tasks_by_context(context_id).await;
+    let tenant = req
+        .params
+        .get("tenant")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let tasks: Vec<Task> = task_store
+        .tasks_by_context(context_id)
+        .await
+        .into_iter()
+        .filter(|t| tenant_matches(t.tenant.as_deref(), tenant))
+        .collect();
     (
         StatusCode::OK,
         Json(json!({
@@ -1382,12 +1473,32 @@ fn unwrap_rpc_to_rest(
     )
 }
 
-/// `POST /message:send` — v1.0 REST binding for SendMessage.
-pub async fn handle_message_send_rest(
-    State(state): State<AppState>,
+/// Inject a route-level `tenant` string into a params JSON value, taking
+/// precedence over any caller-supplied `tenant` field.  Returns the
+/// potentially-mutated value ready to hand off to the inner RPC handler.
+fn inject_tenant(mut params: serde_json::Value, tenant: &str) -> serde_json::Value {
+    if tenant.is_empty() {
+        return params;
+    }
+    if !params.is_object() {
+        params = json!({});
+    }
+    if let Some(obj) = params.as_object_mut() {
+        obj.insert("tenant".to_string(), json!(tenant));
+    }
+    params
+}
+
+/// Shared body for the `POST /message:send` and
+/// `POST /{tenant}/message:send` handlers.  The `tenant` argument is
+/// taken from the URL path; when non-empty it overrides any `tenant`
+/// field in the JSON body.
+async fn handle_message_send_rest_inner(
+    state: AppState,
     headers: HeaderMap,
-    Json(params): Json<serde_json::Value>,
-) -> impl IntoResponse {
+    tenant: String,
+    params: serde_json::Value,
+) -> axum::response::Response {
     let (Some(_card), Some(task_store)) = (&state.a2a_agent_card, &state.a2a_task_store) else {
         return (
             StatusCode::NOT_FOUND,
@@ -1404,18 +1515,39 @@ pub async fn handle_message_send_rest(
         jsonrpc: "2.0".into(),
         id: json!(uuid::Uuid::new_v4().to_string()),
         method: "message/send".into(),
-        params,
+        params: inject_tenant(params, &tenant),
     };
     let (status, Json(body)) = Box::pin(handle_message_send(&state, task_store, req)).await;
     unwrap_rpc_to_rest(status, body).into_response()
 }
 
-/// `GET /tasks/{id}` — v1.0 REST binding for GetTask.
-pub async fn handle_tasks_get_rest(
+/// `POST /message:send` — v1.0 REST binding for SendMessage.
+pub async fn handle_message_send_rest(
     State(state): State<AppState>,
     headers: HeaderMap,
-    axum::extract::Path(task_id): axum::extract::Path<String>,
+    Json(params): Json<serde_json::Value>,
 ) -> impl IntoResponse {
+    handle_message_send_rest_inner(state, headers, String::new(), params).await
+}
+
+/// `POST /{tenant}/message:send` — tenant-scoped v1.0 REST binding.
+pub async fn handle_message_send_rest_scoped(
+    State(state): State<AppState>,
+    axum::extract::Path(tenant): axum::extract::Path<String>,
+    headers: HeaderMap,
+    Json(params): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    handle_message_send_rest_inner(state, headers, tenant, params).await
+}
+
+/// Shared body for the `GET /tasks/{id}` and
+/// `GET /{tenant}/tasks/{id}` handlers.
+async fn handle_tasks_get_rest_inner(
+    state: AppState,
+    headers: HeaderMap,
+    tenant: String,
+    task_id: String,
+) -> axum::response::Response {
     let (Some(_card), Some(task_store)) = (&state.a2a_agent_card, &state.a2a_task_store) else {
         return (
             StatusCode::NOT_FOUND,
@@ -1432,20 +1564,37 @@ pub async fn handle_tasks_get_rest(
         jsonrpc: "2.0".into(),
         id: json!(uuid::Uuid::new_v4().to_string()),
         method: "tasks/get".into(),
-        params: json!({"id": task_id}),
+        params: inject_tenant(json!({"id": task_id}), &tenant),
     };
     let (status, Json(body)) = handle_tasks_get(task_store, req).await;
     unwrap_rpc_to_rest(status, body).into_response()
 }
 
-/// `POST /tasks/{id}:cancel` — v1.0 REST binding for CancelTask.
-/// The route captures the full `{id}:cancel` segment; the `:cancel` suffix
-/// is stripped at runtime because axum does not support `{param}:suffix` patterns.
-pub async fn handle_tasks_cancel_rest(
+/// `GET /tasks/{id}` — v1.0 REST binding for GetTask.
+pub async fn handle_tasks_get_rest(
     State(state): State<AppState>,
     headers: HeaderMap,
-    axum::extract::Path(raw): axum::extract::Path<String>,
+    axum::extract::Path(task_id): axum::extract::Path<String>,
 ) -> impl IntoResponse {
+    handle_tasks_get_rest_inner(state, headers, String::new(), task_id).await
+}
+
+/// `GET /{tenant}/tasks/{id}` — tenant-scoped v1.0 REST binding.
+pub async fn handle_tasks_get_rest_scoped(
+    State(state): State<AppState>,
+    axum::extract::Path((tenant, task_id)): axum::extract::Path<(String, String)>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    handle_tasks_get_rest_inner(state, headers, tenant, task_id).await
+}
+
+/// Shared body for `POST /tasks/{id}:cancel` and the tenant-scoped variant.
+async fn handle_tasks_cancel_rest_inner(
+    state: AppState,
+    headers: HeaderMap,
+    tenant: String,
+    raw: String,
+) -> axum::response::Response {
     // A2A spec uses gRPC-style `/tasks/{id}:cancel` but axum captures
     // the full segment including the `:cancel` suffix.
     let task_id = raw.strip_suffix(":cancel").unwrap_or(&raw).to_string();
@@ -1465,10 +1614,30 @@ pub async fn handle_tasks_cancel_rest(
         jsonrpc: "2.0".into(),
         id: json!(uuid::Uuid::new_v4().to_string()),
         method: "tasks/cancel".into(),
-        params: json!({"id": task_id}),
+        params: inject_tenant(json!({"id": task_id}), &tenant),
     };
     let (status, Json(body)) = handle_tasks_cancel(task_store, req).await;
     unwrap_rpc_to_rest(status, body).into_response()
+}
+
+/// `POST /tasks/{id}:cancel` — v1.0 REST binding for CancelTask.
+/// The route captures the full `{id}:cancel` segment; the `:cancel` suffix
+/// is stripped at runtime because axum does not support `{param}:suffix` patterns.
+pub async fn handle_tasks_cancel_rest(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    axum::extract::Path(raw): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    handle_tasks_cancel_rest_inner(state, headers, String::new(), raw).await
+}
+
+/// `POST /{tenant}/tasks/{id}:cancel` — tenant-scoped cancel handler.
+pub async fn handle_tasks_cancel_rest_scoped(
+    State(state): State<AppState>,
+    axum::extract::Path((tenant, raw)): axum::extract::Path<(String, String)>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    handle_tasks_cancel_rest_inner(state, headers, tenant, raw).await
 }
 
 /// Query parameters for `GET /tasks`.
@@ -1483,12 +1652,13 @@ pub struct ListTasksQuery {
     pub status_timestamp_after: Option<String>,
 }
 
-/// `GET /tasks` — v1.0 REST binding for ListTasks.
-pub async fn handle_tasks_list_rest(
-    State(state): State<AppState>,
+/// Shared body for `GET /tasks` and the tenant-scoped variant.
+async fn handle_tasks_list_rest_inner(
+    state: AppState,
     headers: HeaderMap,
-    axum::extract::Query(query): axum::extract::Query<ListTasksQuery>,
-) -> impl IntoResponse {
+    tenant: String,
+    query: ListTasksQuery,
+) -> axum::response::Response {
     let (Some(_card), Some(task_store)) = (&state.a2a_agent_card, &state.a2a_task_store) else {
         return (
             StatusCode::NOT_FOUND,
@@ -1528,10 +1698,29 @@ pub async fn handle_tasks_list_rest(
         jsonrpc: "2.0".into(),
         id: json!(uuid::Uuid::new_v4().to_string()),
         method: "tasks/list".into(),
-        params,
+        params: inject_tenant(params, &tenant),
     };
     let (status, Json(body)) = handle_tasks_list(task_store, req).await;
     unwrap_rpc_to_rest(status, body).into_response()
+}
+
+/// `GET /tasks` — v1.0 REST binding for ListTasks.
+pub async fn handle_tasks_list_rest(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    axum::extract::Query(query): axum::extract::Query<ListTasksQuery>,
+) -> impl IntoResponse {
+    handle_tasks_list_rest_inner(state, headers, String::new(), query).await
+}
+
+/// `GET /{tenant}/tasks` — tenant-scoped v1.0 REST binding.
+pub async fn handle_tasks_list_rest_scoped(
+    State(state): State<AppState>,
+    axum::extract::Path(tenant): axum::extract::Path<String>,
+    headers: HeaderMap,
+    axum::extract::Query(query): axum::extract::Query<ListTasksQuery>,
+) -> impl IntoResponse {
+    handle_tasks_list_rest_inner(state, headers, tenant, query).await
 }
 
 /// `GET /tasks/by-context/{context_id}` — v1.0 REST binding for tasks by context.
@@ -1563,6 +1752,21 @@ pub async fn handle_tasks_by_context_rest(
 }
 
 // ── v1.0 SSE streaming endpoint ──────────────────────────────────
+
+/// `POST /{tenant}/message:stream` — tenant-scoped streaming handler.
+///
+/// Injects the path-captured tenant into the JSON params envelope (overriding
+/// any caller-supplied `tenant`) and then delegates to
+/// [`handle_message_stream_rest`].
+pub async fn handle_message_stream_rest_scoped(
+    state: State<AppState>,
+    axum::extract::Path(tenant): axum::extract::Path<String>,
+    headers: HeaderMap,
+    Json(params): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let params = inject_tenant(params, &tenant);
+    handle_message_stream_rest(state, headers, Json(params)).await
+}
 
 /// `POST /message:stream` — v1.0 REST binding for `SendStreamingMessage`.
 ///
@@ -1600,6 +1804,18 @@ pub async fn handle_message_stream_rest(
         }
     };
 
+    // A2A v1.0 multi-tenancy: opaque tenant string from params envelope.
+    let tenant = params
+        .get("tenant")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let task_tenant = if tenant.is_empty() {
+        None
+    } else {
+        Some(tenant.clone())
+    };
+
     let task_id = uuid::Uuid::new_v4().to_string();
     let task_store = Arc::clone(task_store);
 
@@ -1629,6 +1845,7 @@ pub async fn handle_message_stream_rest(
                 artifacts: None,
                 history: Some(vec![inbound_msg]),
                 metadata: None,
+                tenant: task_tenant.clone(),
             },
         );
     }
@@ -2474,6 +2691,7 @@ mod tests {
                     artifacts: None,
                     history: None,
                     metadata: None,
+                    tenant: None,
                 },
             );
         }
@@ -2808,6 +3026,7 @@ mod tests {
                     }]),
                     history: None,
                     metadata: None,
+                    tenant: None,
                 },
             );
         }
@@ -2862,6 +3081,7 @@ mod tests {
                     artifacts: None,
                     history: None,
                     metadata: None,
+                    tenant: None,
                 },
             );
         }
@@ -2911,6 +3131,7 @@ mod tests {
                     artifacts: None,
                     history: None,
                     metadata: None,
+                    tenant: None,
                 },
             );
         }
@@ -2957,6 +3178,7 @@ mod tests {
                     artifacts: None,
                     history: None,
                     metadata: None,
+                    tenant: None,
                 },
             );
         }
@@ -2991,6 +3213,7 @@ mod tests {
                     artifacts: None,
                     history: None,
                     metadata: None,
+                    tenant: None,
                 },
             );
         }
@@ -3028,6 +3251,7 @@ mod tests {
                         artifacts: None,
                         history: None,
                         metadata: None,
+                        tenant: None,
                     },
                 );
             }
@@ -3188,6 +3412,7 @@ mod tests {
                         artifacts: None,
                         history: None,
                         metadata: None,
+                        tenant: None,
                     },
                 );
             }
@@ -3230,6 +3455,7 @@ mod tests {
                         artifacts: None,
                         history: None,
                         metadata: None,
+                        tenant: None,
                     },
                 );
             }
@@ -3377,6 +3603,7 @@ mod tests {
                 },
             ]),
             metadata: None,
+            tenant: None,
         }
     }
 
@@ -3611,6 +3838,7 @@ mod tests {
                     artifacts: None,
                     history: None,
                     metadata: None,
+                    tenant: None,
                 },
             );
             tasks.insert(
@@ -3626,6 +3854,7 @@ mod tests {
                     artifacts: None,
                     history: None,
                     metadata: None,
+                    tenant: None,
                 },
             );
             tasks.insert(
@@ -3641,6 +3870,7 @@ mod tests {
                     artifacts: None,
                     history: None,
                     metadata: None,
+                    tenant: None,
                 },
             );
         }
@@ -3677,6 +3907,7 @@ mod tests {
                         artifacts: None,
                         history: None,
                         metadata: None,
+                        tenant: None,
                     },
                 );
             }
@@ -3730,6 +3961,7 @@ mod tests {
                 artifacts: None,
                 history: None,
                 metadata: None,
+                tenant: None,
             },
         );
     }
@@ -3888,6 +4120,7 @@ mod tests {
                     artifacts: None,
                     history: None,
                     metadata: None,
+                    tenant: None,
                 },
             );
         }
@@ -3911,5 +4144,184 @@ mod tests {
             !idx.contains_key("ctx-1"),
             "empty context should be removed from index"
         );
+    }
+
+    // ── Tenant (multi-tenancy v1.0) tests ────────────────────
+
+    /// Insert a task with a specific tenant tag directly into the store.
+    async fn insert_tenant_task(store: &TaskStore, id: &str, tenant: Option<&str>) {
+        let mut tasks = store.tasks.write().await;
+        tasks.insert(
+            id.to_string(),
+            Task {
+                id: id.to_string(),
+                status: TaskStatus {
+                    state: A2aTaskState::Working,
+                    message: None,
+                    timestamp: None,
+                },
+                context_id: None,
+                artifacts: None,
+                history: None,
+                metadata: None,
+                tenant: tenant.map(|s| s.to_string()),
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn tasks_get_scoped_isolates_tenants() {
+        let store = Arc::new(TaskStore::new());
+        insert_tenant_task(&store, "t-a", Some("acme")).await;
+
+        // Tenant "acme" can see its task.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "tasks/get".into(),
+            params: json!({"id": "t-a", "tenant": "acme"}),
+        };
+        let (_, Json(body)) = handle_tasks_get(&store, req).await;
+        assert_eq!(body["result"]["id"], "t-a");
+
+        // Tenant "beta" does not.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "tasks/get".into(),
+            params: json!({"id": "t-a", "tenant": "beta"}),
+        };
+        let (_, Json(body)) = handle_tasks_get(&store, req).await;
+        assert_eq!(body["error"]["code"], -32001);
+
+        // Unscoped (default tenant) also does not see acme's task.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "tasks/get".into(),
+            params: json!({"id": "t-a"}),
+        };
+        let (_, Json(body)) = handle_tasks_get(&store, req).await;
+        assert_eq!(body["error"]["code"], -32001);
+    }
+
+    #[tokio::test]
+    async fn tasks_list_filters_by_tenant() {
+        let store = Arc::new(TaskStore::new());
+        insert_tenant_task(&store, "t-default", None).await;
+        insert_tenant_task(&store, "t-acme", Some("acme")).await;
+        insert_tenant_task(&store, "t-beta", Some("beta")).await;
+
+        // Unscoped list returns only the default-tenant task.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "tasks/list".into(),
+            params: json!({}),
+        };
+        let (_, Json(body)) = handle_tasks_list(&store, req).await;
+        let ids: Vec<&str> = body["result"]["tasks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["t-default"]);
+
+        // Scoped list returns only the matching tenant's task.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "tasks/list".into(),
+            params: json!({"tenant": "acme"}),
+        };
+        let (_, Json(body)) = handle_tasks_list(&store, req).await;
+        let ids: Vec<&str> = body["result"]["tasks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["t-acme"]);
+    }
+
+    #[tokio::test]
+    async fn tasks_cancel_scoped_rejects_wrong_tenant() {
+        let store = Arc::new(TaskStore::new());
+        insert_tenant_task(&store, "t-a", Some("acme")).await;
+
+        // Wrong tenant should see TASK_NOT_FOUND.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "tasks/cancel".into(),
+            params: json!({"id": "t-a", "tenant": "beta"}),
+        };
+        let (_, Json(body)) = handle_tasks_cancel(&store, req).await;
+        assert_eq!(body["error"]["code"], -32001);
+
+        // Correct tenant succeeds.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "tasks/cancel".into(),
+            params: json!({"id": "t-a", "tenant": "acme"}),
+        };
+        let (_, Json(body)) = handle_tasks_cancel(&store, req).await;
+        assert_eq!(body["result"]["status"]["state"], "TASK_STATE_CANCELED");
+    }
+
+    #[test]
+    fn inject_tenant_overrides_caller_value() {
+        // Route tenant wins over body tenant (prevents spoofing from inside
+        // the JSON body when the client hits a scoped route).
+        let params = json!({"id": "abc", "tenant": "attacker"});
+        let out = inject_tenant(params, "acme");
+        assert_eq!(out["tenant"], "acme");
+    }
+
+    #[test]
+    fn inject_tenant_empty_preserves_caller_value() {
+        // Unscoped route passes "" — body tenant must be preserved so that
+        // RPC clients can still pass tenant in the envelope.
+        let params = json!({"id": "abc", "tenant": "acme"});
+        let out = inject_tenant(params, "");
+        assert_eq!(out["tenant"], "acme");
+    }
+
+    #[test]
+    fn tenant_matches_default_semantics() {
+        // None and "" both represent the default tenant.
+        assert!(tenant_matches(None, ""));
+        assert!(tenant_matches(Some(""), ""));
+        assert!(tenant_matches(Some("acme"), "acme"));
+        assert!(!tenant_matches(Some("acme"), ""));
+        assert!(!tenant_matches(None, "acme"));
+        assert!(!tenant_matches(Some("acme"), "beta"));
+    }
+
+    #[tokio::test]
+    async fn message_send_records_tenant_from_params() {
+        let state = a2a_test_state(None, false, &[]);
+        let task_store = state.a2a_task_store.clone().unwrap();
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "message/send".into(),
+            params: json!({
+                "message": {
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "hi"}],
+                    "messageId": "m1"
+                },
+                "tenant": "acme"
+            }),
+        };
+        // Fire-and-forget — the MockProvider will error; we only care that
+        // the task is recorded with the tenant before processing starts.
+        let _ = Box::pin(handle_message_send(&state, &task_store, req)).await;
+        let tasks = task_store.tasks.read().await;
+        let any_acme = tasks.values().any(|t| t.tenant.as_deref() == Some("acme"));
+        assert!(any_acme, "a task should have been stored with tenant=acme");
     }
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -923,7 +923,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
             );
         }
 
-        let card = a2a::generate_agent_card(&config);
+        let card = a2a::generate_agent_card(&config, a2a::CardScope::Public);
         tracing::info!("A2A protocol enabled — agent card generated");
         let task_store = Arc::new(a2a::TaskStore::new());
 
@@ -1025,6 +1025,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         Some(
             Router::new()
                 .route("/.well-known/agent-card.json", get(a2a::handle_agent_card))
+                .route("/extendedAgentCard", get(a2a::handle_extended_agent_card))
                 .route("/message:send", post(a2a::handle_message_send_rest))
                 .route("/message:stream", post(a2a::handle_message_stream_rest))
                 .route("/tasks", get(a2a::handle_tasks_list_rest))

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1037,6 +1037,26 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
                     "/tasks/by-context/{context_id}",
                     get(a2a::handle_tasks_by_context_rest),
                 )
+                // A2A v1.0 multi-tenancy: tenant-scoped route mirrors of
+                // the routes above.  The path-captured `{tenant}` is
+                // injected into the JSON-RPC params envelope, overriding
+                // any caller-supplied `tenant` field.  Tenant is opaque
+                // metadata — no authorization is enforced beyond the
+                // existing bearer/pairing checks.
+                .route(
+                    "/{tenant}/message:send",
+                    post(a2a::handle_message_send_rest_scoped),
+                )
+                .route(
+                    "/{tenant}/message:stream",
+                    post(a2a::handle_message_stream_rest_scoped),
+                )
+                .route("/{tenant}/tasks", get(a2a::handle_tasks_list_rest_scoped))
+                .route(
+                    "/{tenant}/tasks/{id}",
+                    get(a2a::handle_tasks_get_rest_scoped)
+                        .post(a2a::handle_tasks_cancel_rest_scoped),
+                )
                 .route("/a2a", post(a2a::handle_a2a_rpc))
                 .layer(DefaultBodyLimit::max(config.a2a.body_limit_bytes)),
         )


### PR DESCRIPTION
Closes #65.  Part of epic #66 — this is the last open A2A v1.0 feature
issue on the tracker.

## Summary

### Part A — GetExtendedAgentCard

- New route `GET /extendedAgentCard` returns an agent card that
  additionally advertises skills listed in the new
  `A2aConfig.extended_skills`.  Reuses `require_a2a_auth`, so bearer
  and pairing are enforced identically to other A2A routes.
- The public `/.well-known/agent-card.json` stays unauthenticated and
  advertises only `capabilities`.
- When `extended_skills` is non-empty, the public card advertises
  `capabilities.extendedAgentCard = true` so clients know to call the
  authenticated endpoint.
- `CardScope::{Public, Extended}` drives the single
  `generate_agent_card` — no duplicated card-assembly logic.

### Part B — Multi-tenancy

- `Task` gains `Option<String> tenant` (`None`/"" == default tenant).
- `message/send` and `message/stream` read `tenant` from the params
  envelope and record it on the created task.
- `tasks/get`, `tasks/cancel`, `tasks/list`, `tasks/getByContextId`
  filter by tenant — tenant-A tasks return 404 under tenant B, and the
  unscoped routes (default tenant) see only default-tenant tasks, not
  a superset.
- Parallel `/{tenant}/...` REST routes mirror the existing ones;
  shared `*_inner` helpers prevent handler duplication.
  `inject_tenant()` puts the path-captured tenant into the RPC params,
  overriding any caller-supplied body `tenant` (prevents spoofing from
  inside the body on a scoped route).
- New `A2aConfig.default_tenant: Option<String>` — when set, each
  AgentInterface entry in the card's `supported_interfaces` is tagged
  with that tenant.

### Explicitly NOT included

- Tenant-based AUTHORIZATION.  Tenant is opaque metadata; any
  authenticated caller may use any tenant string.  Per-tenant auth is
  out of scope per #65.
- Push-notification config storage (does not exist on master).

## Test plan

New tests (13 total across both features):

Extended card (6):
- `extended_agent_card_requires_auth_when_token_configured`
- `extended_agent_card_returns_extended_skills_when_authenticated`
- `public_card_omits_extended_skills`
- `public_card_advertises_extended_capability_when_extended_skills_present`
- `public_card_omits_extended_capability_when_no_extended_skills`
- `agent_card_includes_default_tenant_on_interface`

Tenancy (7):
- `tasks_get_scoped_isolates_tenants`
- `tasks_list_filters_by_tenant`
- `tasks_cancel_scoped_rejects_wrong_tenant`
- `inject_tenant_overrides_caller_value`
- `inject_tenant_empty_preserves_caller_value`
- `tenant_matches_default_semantics`
- `message_send_records_tenant_from_params`

Verification:
- [x] `cargo test --lib --features tool-a2a gateway::` — 201 passed, 0 failed
- [x] `cargo clippy --features tool-a2a --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] All pre-existing A2A behavior unchanged (58 pre-existing a2a tests
      all still green alongside the 13 new ones, for 71 total in
      `gateway::a2a::tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)