### PR TITLE
feat: seed hrafn microkernel architecture

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -44,7 +44,9 @@ jobs:
   bench-compile:
     name: Verify Benchmarks Compile
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # This job routinely finishes just under 15 minutes on cold PR runners;
+    # leave cleanup/logging headroom so successful compiles are not cancelled.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3993,6 +3993,7 @@ dependencies = [
  "hex",
  "hmac",
  "hostname",
+ "hrafn-sdk",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -4089,6 +4090,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hrafn-kernel"
+version = "0.1.0"
+dependencies = [
+ "hrafn-sdk",
+]
+
+[[package]]
 name = "hrafn-robot-kit"
 version = "0.1.0"
 dependencies = [
@@ -4108,6 +4116,15 @@ dependencies = [
  "tokio-test",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
+]
+
+[[package]]
+name = "hrafn-sdk"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,6 +4109,7 @@ name = "hrafn-kernel"
 version = "0.1.0"
 dependencies = [
  "hrafn-sdk",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1590,7 +1590,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -2398,7 +2398,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2712,7 +2712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3045,12 +3045,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -3063,6 +3072,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -5976,6 +5991,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11ec1bc47d34ae756616f387c11fd0595f86f2cc7e6473bde9e3ded30cb902a1"
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6204,7 +6236,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6299,7 +6331,7 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "slab",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6623,10 +6655,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -6736,7 +6806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7539,7 +7609,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8394,12 +8464,10 @@ dependencies = [
  "flume",
  "futures-util",
  "log",
- "rustls-native-certs",
- "rustls-pemfile",
- "rustls-webpki 0.102.8",
+ "native-tls",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tokio-stream",
  "tokio-util",
 ]
@@ -8502,7 +8570,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8526,7 +8594,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.11",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -8564,20 +8632,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -9271,7 +9328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9940,7 +9997,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10122,6 +10179,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -10700,7 +10767,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12101,7 +12168,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,10 @@ nanohtml2text = { version = "0.2", optional = true }
 # Optional Rust-native browser automation backend
 fantoccini = { version = "0.22.1", optional = true, default-features = false, features = ["rustls-tls"] }
 
-# MQTT client for IoT / SOP event fan-in
-rumqttc = { version = "0.25", optional = true }
+# MQTT client for IoT / SOP event fan-in.
+# Use native TLS instead of rumqttc's default rustls stack until rumqttc
+# updates its rustls-webpki 0.102 dependency past RUSTSEC-2026-0098/0099/0104.
+rumqttc = { version = "0.25", optional = true, default-features = false, features = ["use-native-tls"] }
 
 # Tarball extraction for binary updates
 flate2 = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/robot-kit", "crates/aardvark-sys", "apps/tauri"]
+members = [".", "crates/hrafn-sdk", "crates/hrafn-kernel", "crates/robot-kit", "crates/aardvark-sys", "apps/tauri"]
 resolver = "2"
 
 [package]
@@ -35,11 +35,15 @@ name = "hrafn-esp32"
 path = "src/bin/esp32.rs"
 required-features = ["target-esp32"]
 
+
 [lib]
 name = "hrafn"
 path = "src/lib.rs"
 
 [dependencies]
+# Microkernel SDK boundary
+hrafn-sdk = { path = "crates/hrafn-sdk", version = "0.1.0", optional = true }
+
 # CLI - minimal and fast (desktop only)
 clap = { version = "4.5", features = ["derive"], optional = true }
 clap_complete = { version = "4.5", optional = true }
@@ -257,7 +261,12 @@ landlock = { version = "0.4", optional = true }
 libc = "0.2"
 
 [features]
-default = [
+default = ["full"]
+# Minimal microkernel seed: compiles only the SDK-backed kernel binary without desktop integrations.
+kernel = ["dep:hrafn-sdk"]
+# Explicit full distribution profile. This preserves the historical default feature set while
+# making the monolith profile named and separable from the future microkernel default.
+full = [
     "desktop",
     "tui",
     "observability-prometheus",
@@ -274,6 +283,7 @@ default = [
 # Desktop feature: includes all desktop-only dependencies.
 # Disable with --no-default-features for embedded builds.
 desktop = [
+    "dep:hrafn-sdk",
     "dep:clap", "dep:clap_complete",
     "dep:dialoguer", "dep:console",
     "gateway",

--- a/crates/hrafn-kernel/Cargo.toml
+++ b/crates/hrafn-kernel/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hrafn-kernel"
+version = "0.1.0"
+edition = "2024"
+authors = ["Christian Pojoni", "5queezer"]
+license = "MIT OR Apache-2.0"
+description = "Minimal Hrafn microkernel host seed"
+repository = "https://github.com/5queezer/hrafn"
+rust-version = "1.87"
+
+[dependencies]
+hrafn-sdk = { path = "../hrafn-sdk", version = "0.1.0" }

--- a/crates/hrafn-kernel/Cargo.toml
+++ b/crates/hrafn-kernel/Cargo.toml
@@ -9,4 +9,5 @@ repository = "https://github.com/5queezer/hrafn"
 rust-version = "1.87"
 
 [dependencies]
-hrafn-sdk = { path = "../hrafn-sdk", version = "0.1.0" }
+hrafn-sdk = { path = "../hrafn-sdk", version = "0.1.0", default-features = false }
+thiserror = "2.0"

--- a/crates/hrafn-kernel/src/lib.rs
+++ b/crates/hrafn-kernel/src/lib.rs
@@ -1,0 +1,91 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use hrafn_sdk::PluginManifest;
+
+/// Permission-aware registry for plugins known to the Hrafn microkernel.
+#[derive(Debug, Default)]
+pub struct KernelRegistry {
+    granted_permissions: BTreeSet<String>,
+    plugins: BTreeMap<String, PluginManifest>,
+}
+
+impl KernelRegistry {
+    #[must_use]
+    pub fn new<I, S>(granted_permissions: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            granted_permissions: granted_permissions.into_iter().map(Into::into).collect(),
+            plugins: BTreeMap::new(),
+        }
+    }
+
+    /// Register a plugin manifest after enforcing duplicate-name and permission policy.
+    ///
+    /// This is intentionally small: it is the seed of the future kernel/plugin boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryError::DuplicatePlugin`] when a plugin with the same name is
+    /// already registered. Returns [`RegistryError::PermissionDenied`] when the plugin
+    /// requests a permission that has not been granted to the kernel registry.
+    pub fn register(&mut self, manifest: PluginManifest) -> Result<(), RegistryError> {
+        if self.plugins.contains_key(&manifest.name) {
+            return Err(RegistryError::DuplicatePlugin(manifest.name));
+        }
+
+        for permission in &manifest.permissions {
+            if !self.granted_permissions.contains(&permission.scope) {
+                return Err(RegistryError::PermissionDenied {
+                    plugin: manifest.name,
+                    permission: permission.scope.clone(),
+                });
+            }
+        }
+
+        self.plugins.insert(manifest.name.clone(), manifest);
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&PluginManifest> {
+        self.plugins.get(name)
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.plugins.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.plugins.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryError {
+    DuplicatePlugin(String),
+    PermissionDenied { plugin: String, permission: String },
+}
+
+impl std::fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DuplicatePlugin(name) => write!(f, "plugin {name} is already registered"),
+            Self::PermissionDenied { plugin, permission } => {
+                write!(
+                    f,
+                    "plugin {plugin} requested ungranted permission {permission}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RegistryError {}

--- a/crates/hrafn-kernel/src/lib.rs
+++ b/crates/hrafn-kernel/src/lib.rs
@@ -28,6 +28,11 @@ impl KernelRegistry {
     /// Register a plugin manifest after enforcing duplicate-name and permission policy.
     ///
     /// This is intentionally small: it is the seed of the future kernel/plugin boundary.
+    /// Permission matching is exact-string only: every [`hrafn_sdk::Permission::scope`] in
+    /// [`PluginManifest::permissions`] must exactly match one entry in
+    /// `granted_permissions`. There is no hierarchy, prefix/glob matching, or
+    /// normalization at this boundary yet; changing that policy later would be a
+    /// compatibility-affecting protocol change.
     ///
     /// # Errors
     ///
@@ -68,24 +73,10 @@ impl KernelRegistry {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum RegistryError {
+    #[error("plugin {0} is already registered")]
     DuplicatePlugin(String),
+    #[error("plugin {plugin} requested ungranted permission {permission}")]
     PermissionDenied { plugin: String, permission: String },
 }
-
-impl std::fmt::Display for RegistryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::DuplicatePlugin(name) => write!(f, "plugin {name} is already registered"),
-            Self::PermissionDenied { plugin, permission } => {
-                write!(
-                    f,
-                    "plugin {plugin} requested ungranted permission {permission}"
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for RegistryError {}

--- a/crates/hrafn-kernel/src/main.rs
+++ b/crates/hrafn-kernel/src/main.rs
@@ -8,14 +8,14 @@ fn main() {
         ExtensionKind::Runtime,
     )
     .with_capability("kernel.registry")
-    .with_capability("kernel.permissions");
-    let mut registry = KernelRegistry::default();
+    .with_permission("kernel.permissions");
+    let mut registry = KernelRegistry::new(["kernel.permissions"]);
     registry
         .register(manifest.clone())
         .expect("kernel manifest should register");
 
     println!(
-        "{} {} {} plugins={}",
+        "name={} version={} sdk_protocol={} plugins={}",
         manifest.name,
         manifest.version,
         SDK_PROTOCOL_VERSION,

--- a/crates/hrafn-kernel/src/main.rs
+++ b/crates/hrafn-kernel/src/main.rs
@@ -1,0 +1,24 @@
+use hrafn_kernel::KernelRegistry;
+use hrafn_sdk::{ExtensionKind, PluginManifest, SDK_PROTOCOL_VERSION};
+
+fn main() {
+    let manifest = PluginManifest::new(
+        "hrafn-kernel",
+        env!("CARGO_PKG_VERSION"),
+        ExtensionKind::Runtime,
+    )
+    .with_capability("kernel.registry")
+    .with_capability("kernel.permissions");
+    let mut registry = KernelRegistry::default();
+    registry
+        .register(manifest.clone())
+        .expect("kernel manifest should register");
+
+    println!(
+        "{} {} {} plugins={}",
+        manifest.name,
+        manifest.version,
+        SDK_PROTOCOL_VERSION,
+        registry.len()
+    );
+}

--- a/crates/hrafn-kernel/tests/registry.rs
+++ b/crates/hrafn-kernel/tests/registry.rs
@@ -1,0 +1,45 @@
+use hrafn_kernel::{KernelRegistry, RegistryError};
+use hrafn_sdk::{ExtensionKind, PluginManifest};
+
+#[test]
+fn registry_accepts_plugins_with_granted_permissions() {
+    let mut registry = KernelRegistry::new(["network:https://openrouter.ai"].into_iter());
+    let manifest = PluginManifest::new("openrouter", "0.1.0", ExtensionKind::Provider)
+        .with_capability("provider.chat")
+        .with_permission("network:https://openrouter.ai");
+
+    registry.register(manifest).expect("register plugin");
+
+    let plugin = registry.get("openrouter").expect("registered plugin");
+    assert_eq!(plugin.kind, ExtensionKind::Provider);
+    assert_eq!(plugin.capabilities[0].name, "provider.chat");
+}
+
+#[test]
+fn registry_rejects_plugins_with_ungranted_permissions() {
+    let mut registry = KernelRegistry::new(std::iter::empty::<&str>());
+    let manifest = PluginManifest::new("shell", "0.1.0", ExtensionKind::Tool)
+        .with_capability("tool.execute")
+        .with_permission("shell:exec");
+
+    let err = registry.register(manifest).expect_err("permission denied");
+
+    assert_eq!(
+        err,
+        RegistryError::PermissionDenied {
+            plugin: "shell".into(),
+            permission: "shell:exec".into(),
+        }
+    );
+}
+
+#[test]
+fn registry_rejects_duplicate_plugin_names() {
+    let mut registry = KernelRegistry::default();
+    let manifest = PluginManifest::new("duplicate", "0.1.0", ExtensionKind::Tool);
+
+    registry.register(manifest.clone()).expect("first register");
+    let err = registry.register(manifest).expect_err("duplicate rejected");
+
+    assert_eq!(err, RegistryError::DuplicatePlugin("duplicate".into()));
+}

--- a/crates/hrafn-sdk/Cargo.toml
+++ b/crates/hrafn-sdk/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/5queezer/hrafn"
 rust-version = "1.87"
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive", "std"], optional = true }
-serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 thiserror = { version = "2.0", default-features = false, optional = true }
 
 [features]
 default = ["std", "serde"]
-std = []
+std = ["serde?/std", "serde_json?/std"]
 serde = ["dep:serde", "dep:serde_json"]
 error = ["dep:thiserror"]

--- a/crates/hrafn-sdk/Cargo.toml
+++ b/crates/hrafn-sdk/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "hrafn-sdk"
+version = "0.1.0"
+edition = "2024"
+authors = ["Christian Pojoni", "5queezer"]
+license = "MIT OR Apache-2.0"
+description = "Stable SDK types for Hrafn microkernel plugins"
+repository = "https://github.com/5queezer/hrafn"
+rust-version = "1.87"
+
+[dependencies]
+serde = { version = "1.0", default-features = false, features = ["derive", "std"], optional = true }
+serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
+thiserror = { version = "2.0", default-features = false, optional = true }
+
+[features]
+default = ["std", "serde"]
+std = []
+serde = ["dep:serde", "dep:serde_json"]
+error = ["dep:thiserror"]

--- a/crates/hrafn-sdk/src/lib.rs
+++ b/crates/hrafn-sdk/src/lib.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+pub mod prelude;
+pub mod protocol;
+pub mod tool;
+
+pub use protocol::{
+    Capability, ExtensionKind, HandshakeRequest, HandshakeResponse, Permission, PluginManifest,
+    SDK_PROTOCOL_VERSION,
+};
+pub use tool::{ToolResult, ToolSpec};

--- a/crates/hrafn-sdk/src/prelude.rs
+++ b/crates/hrafn-sdk/src/prelude.rs
@@ -1,0 +1,4 @@
+#[cfg(not(feature = "std"))]
+pub use alloc::{string::String, vec::Vec};
+#[cfg(feature = "std")]
+pub use std::{string::String, vec::Vec};

--- a/crates/hrafn-sdk/src/protocol.rs
+++ b/crates/hrafn-sdk/src/protocol.rs
@@ -35,6 +35,18 @@ impl Capability {
     }
 }
 
+impl From<&str> for Capability {
+    fn from(name: &str) -> Self {
+        Self::new(name)
+    }
+}
+
+impl From<String> for Capability {
+    fn from(name: String) -> Self {
+        Self::new(name)
+    }
+}
+
 /// A permission requested by a plugin and granted or denied by policy.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -51,6 +63,18 @@ impl Permission {
     }
 }
 
+impl From<&str> for Permission {
+    fn from(scope: &str) -> Self {
+        Self::new(scope)
+    }
+}
+
+impl From<String> for Permission {
+    fn from(scope: String) -> Self {
+        Self::new(scope)
+    }
+}
+
 /// Minimal manifest returned during plugin handshake.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -58,7 +82,7 @@ pub struct PluginManifest {
     pub name: String,
     pub version: String,
     pub kind: ExtensionKind,
-    pub protocol: String,
+    pub protocol_version: String,
     pub capabilities: Vec<Capability>,
     pub permissions: Vec<Permission>,
 }
@@ -70,21 +94,21 @@ impl PluginManifest {
             name: name.into(),
             version: version.into(),
             kind,
-            protocol: SDK_PROTOCOL_VERSION.into(),
+            protocol_version: SDK_PROTOCOL_VERSION.into(),
             capabilities: Vec::new(),
             permissions: Vec::new(),
         }
     }
 
     #[must_use]
-    pub fn with_capability(mut self, capability: impl Into<String>) -> Self {
-        self.capabilities.push(Capability::new(capability));
+    pub fn with_capability(mut self, capability: impl Into<Capability>) -> Self {
+        self.capabilities.push(capability.into());
         self
     }
 
     #[must_use]
-    pub fn with_permission(mut self, permission: impl Into<String>) -> Self {
-        self.permissions.push(Permission::new(permission));
+    pub fn with_permission(mut self, permission: impl Into<Permission>) -> Self {
+        self.permissions.push(permission.into());
         self
     }
 }

--- a/crates/hrafn-sdk/src/protocol.rs
+++ b/crates/hrafn-sdk/src/protocol.rs
@@ -1,0 +1,105 @@
+use crate::prelude::{String, Vec};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Stable protocol version implemented by this SDK crate.
+pub const SDK_PROTOCOL_VERSION: &str = "hrafn-plugin-jsonrpc-0.1";
+
+/// The broad kind of extension registered with the Hrafn kernel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+pub enum ExtensionKind {
+    Provider,
+    Channel,
+    Tool,
+    Memory,
+    Observer,
+    Runtime,
+    Peripheral,
+    Frontend,
+}
+
+/// A capability advertised by a plugin or granted by the kernel.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Capability {
+    pub name: String,
+}
+
+impl Capability {
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+/// A permission requested by a plugin and granted or denied by policy.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Permission {
+    pub scope: String,
+}
+
+impl Permission {
+    #[must_use]
+    pub fn new(scope: impl Into<String>) -> Self {
+        Self {
+            scope: scope.into(),
+        }
+    }
+}
+
+/// Minimal manifest returned during plugin handshake.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PluginManifest {
+    pub name: String,
+    pub version: String,
+    pub kind: ExtensionKind,
+    pub protocol: String,
+    pub capabilities: Vec<Capability>,
+    pub permissions: Vec<Permission>,
+}
+
+impl PluginManifest {
+    #[must_use]
+    pub fn new(name: impl Into<String>, version: impl Into<String>, kind: ExtensionKind) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+            kind,
+            protocol: SDK_PROTOCOL_VERSION.into(),
+            capabilities: Vec::new(),
+            permissions: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_capability(mut self, capability: impl Into<String>) -> Self {
+        self.capabilities.push(Capability::new(capability));
+        self
+    }
+
+    #[must_use]
+    pub fn with_permission(mut self, permission: impl Into<String>) -> Self {
+        self.permissions.push(Permission::new(permission));
+        self
+    }
+}
+
+/// Kernel-to-plugin handshake request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct HandshakeRequest {
+    pub protocol_version: String,
+    pub kernel_version: String,
+}
+
+/// Plugin-to-kernel handshake response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct HandshakeResponse {
+    pub manifest: PluginManifest,
+}

--- a/crates/hrafn-sdk/src/tool.rs
+++ b/crates/hrafn-sdk/src/tool.rs
@@ -1,0 +1,23 @@
+use crate::prelude::String;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Result of a tool execution.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ToolResult {
+    pub success: bool,
+    pub output: String,
+    pub error: Option<String>,
+}
+
+/// Description of a tool for LLM/function-call registration.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ToolSpec {
+    pub name: String,
+    pub description: String,
+    #[cfg(feature = "serde")]
+    pub parameters: serde_json::Value,
+}

--- a/dev/measure-microkernel.sh
+++ b/dev/measure-microkernel.sh
@@ -27,6 +27,7 @@ echo "+ ${build_cmd[*]}"
 echo
 echo "== dependency feature tree =="
 echo "+ ${tree_cmd[*]}"
+mkdir -p target
 "${tree_cmd[@]}" > "target/hrafn-${profile}-features.txt"
 echo "wrote target/hrafn-${profile}-features.txt"
 

--- a/dev/measure-microkernel.sh
+++ b/dev/measure-microkernel.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+profile="${1:-kernel}"
+
+case "$profile" in
+  kernel)
+    build_cmd=(cargo build -p hrafn-kernel)
+    tree_cmd=(cargo tree -p hrafn-kernel -e features)
+    ;;
+  full)
+    build_cmd=(cargo build --features full --bin hrafn)
+    tree_cmd=(cargo tree --features full --bin hrafn -e features)
+    ;;
+  *)
+    echo "usage: $0 [kernel|full]" >&2
+    exit 2
+    ;;
+esac
+
+echo "== Hrafn build profile: $profile =="
+echo
+
+echo "+ ${build_cmd[*]}"
+"${build_cmd[@]}"
+
+echo
+echo "== dependency feature tree =="
+echo "+ ${tree_cmd[*]}"
+"${tree_cmd[@]}" > "target/hrafn-${profile}-features.txt"
+echo "wrote target/hrafn-${profile}-features.txt"
+
+echo
+if command -v cargo-bloat >/dev/null 2>&1; then
+  if [[ "$profile" == "kernel" ]]; then
+    cargo bloat --release -p hrafn-kernel --crates > "target/hrafn-${profile}-bloat.txt"
+  else
+    cargo bloat --release --features full --bin hrafn --crates > "target/hrafn-${profile}-bloat.txt"
+  fi
+  echo "wrote target/hrafn-${profile}-bloat.txt"
+else
+  echo "cargo-bloat not installed; skipping size attribution"
+  echo "install with: cargo install cargo-bloat"
+fi

--- a/docs/architecture/microkernel.md
+++ b/docs/architecture/microkernel.md
@@ -1,0 +1,74 @@
+# Hrafn Microkernel Migration
+
+Goal: reduce clean/incremental build time and binary size by making the default architecture a small kernel plus optional integrations.
+
+## Current seed
+
+This repository now has a minimal SDK boundary and kernel seed:
+
+- `crates/hrafn-sdk`: dependency-light shared plugin/kernel protocol types.
+- `crates/hrafn-kernel`: tiny standalone kernel seed binary gated away from the full `hrafn` package.
+- `full`: explicit feature profile preserving the historical all-in-one default set.
+- `dev/measure-microkernel.sh`: build/dependency-size measurement helper.
+
+The first invariant is that the SDK must stay small. It must not depend on integration crates such as `reqwest`, `axum`, `ratatui`, `rusqlite`, `matrix-sdk`, or `wa-rs`.
+
+## Intended shape
+
+The kernel owns:
+
+- config loading
+- session routing
+- security policy
+- capability grants
+- audit records
+- event bus
+- plugin lifecycle
+
+Plugins own:
+
+- providers
+- channels
+- tools
+- memory backends
+- gateways/frontends
+- hardware integrations
+
+## Near-term migration order
+
+1. Keep `default = ["full"]` until compatibility is intentionally changed.
+2. Use `crates/hrafn-kernel` to prove that a tiny non-desktop binary can compile without the monolith.
+3. Move stable trait/request/response types from `src/*/traits.rs` into `crates/hrafn-sdk`.
+4. Extract one provider crate, preferably OpenRouter, and register it as an in-process plugin.
+5. Extract one high-risk tool crate, preferably shell, and attach explicit capability metadata.
+6. Extract `gateway` and `tui` into separate crates/binaries so server and CLI builds do not pull those dependencies unless requested.
+7. Add JSON-RPC-over-stdio plugin support for heavy or independently released integrations.
+
+## Measurement
+
+Run:
+
+```bash
+./dev/measure-microkernel.sh kernel
+./dev/measure-microkernel.sh full
+```
+
+Outputs:
+
+- `target/hrafn-kernel-features.txt`
+- `target/hrafn-full-features.txt`
+- optional `target/hrafn-*-bloat.txt` if `cargo-bloat` is installed
+
+## Build commands
+
+Minimal kernel seed:
+
+```bash
+cargo build -p hrafn-kernel
+```
+
+Historical full distribution:
+
+```bash
+cargo build --features full --bin hrafn
+```

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -32,6 +32,20 @@ Fix:
 ./install.sh --install-system-deps
 ```
 
+Full desktop builds that enable MQTT use `rumqttc` with native TLS so the
+workspace avoids known `rustls-webpki` audit findings in the older MQTT TLS
+stack. On Linux, that path requires OpenSSL development headers and
+`pkg-config`:
+
+```bash
+sudo apt-get install -y pkg-config libssl-dev
+```
+
+Native TLS also delegates certificate validation to the platform TLS stack
+(OpenSSL on Linux, SChannel on Windows, Secure Transport on macOS). Brokers with
+non-standard or private certificate chains can therefore behave differently than
+the prior rustls-backed MQTT configuration.
+
 ### Build fails on low-RAM / low-disk hosts
 
 Symptoms:

--- a/src/agent/classifier.rs
+++ b/src/agent/classifier.rs
@@ -29,7 +29,7 @@ pub fn classify_with_decision(
     let len = message.len();
 
     let mut rules: Vec<_> = config.rules.iter().collect();
-    rules.sort_by(|a, b| b.priority.cmp(&a.priority));
+    rules.sort_by_key(|b| std::cmp::Reverse(b.priority));
 
     for rule in rules {
         // Length constraints

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -3220,7 +3220,7 @@ pub(crate) async fn run_tool_call_loop(
         for ((idx, call), outcome) in executable_indices
             .iter()
             .zip(executable_calls.iter())
-            .zip(executed_outcomes.into_iter())
+            .zip(executed_outcomes)
         {
             runtime_trace::record_event(
                 "tool_call_result",

--- a/src/channels/irc.rs
+++ b/src/channels/irc.rs
@@ -432,48 +432,41 @@ impl Channel for IrcChannel {
                 }
 
                 // CAP responses for SASL
-                "CAP" => {
-                    if sasl_pending && msg.params.iter().any(|p| p.contains("sasl")) {
-                        if msg.params.iter().any(|p| p.contains("ACK")) {
-                            // CAP * ACK :sasl — server accepted, start SASL auth
-                            let mut guard = self.writer.lock().await;
-                            if let Some(ref mut w) = *guard {
-                                Self::send_raw(w, "AUTHENTICATE PLAIN").await?;
-                            }
-                        } else if msg.params.iter().any(|p| p.contains("NAK")) {
-                            // CAP * NAK :sasl — server rejected SASL, proceed without it
-                            tracing::warn!(
-                                "IRC server does not support SASL, continuing without it"
-                            );
-                            sasl_pending = false;
-                            let mut guard = self.writer.lock().await;
-                            if let Some(ref mut w) = *guard {
-                                Self::send_raw(w, "CAP END").await?;
-                            }
+                "CAP" if sasl_pending && msg.params.iter().any(|p| p.contains("sasl")) => {
+                    if msg.params.iter().any(|p| p.contains("ACK")) {
+                        // CAP * ACK :sasl — server accepted, start SASL auth
+                        let mut guard = self.writer.lock().await;
+                        if let Some(ref mut w) = *guard {
+                            Self::send_raw(w, "AUTHENTICATE PLAIN").await?;
+                        }
+                    } else if msg.params.iter().any(|p| p.contains("NAK")) {
+                        // CAP * NAK :sasl — server rejected SASL, proceed without it
+                        tracing::warn!("IRC server does not support SASL, continuing without it");
+                        sasl_pending = false;
+                        let mut guard = self.writer.lock().await;
+                        if let Some(ref mut w) = *guard {
+                            Self::send_raw(w, "CAP END").await?;
                         }
                     }
                 }
 
-                "AUTHENTICATE" => {
-                    // Server sends "AUTHENTICATE +" to request credentials
-                    if sasl_pending && msg.params.first().is_some_and(|p| p == "+") {
-                        // sasl_password is loaded from runtime config, not hard-coded
-                        if let Some(password) = self.sasl_password.as_deref() {
-                            let encoded = encode_sasl_plain(&current_nick, password);
-                            let mut guard = self.writer.lock().await;
-                            if let Some(ref mut w) = *guard {
-                                Self::send_raw(w, &format!("AUTHENTICATE {encoded}")).await?;
-                            }
-                        } else {
-                            // SASL was requested but no password is configured; abort SASL
-                            tracing::warn!(
-                                "SASL authentication requested but no SASL password is configured; aborting SASL"
-                            );
-                            sasl_pending = false;
-                            let mut guard = self.writer.lock().await;
-                            if let Some(ref mut w) = *guard {
-                                Self::send_raw(w, "CAP END").await?;
-                            }
+                "AUTHENTICATE" if sasl_pending && msg.params.first().is_some_and(|p| p == "+") => {
+                    // sasl_password is loaded from runtime config, not hard-coded
+                    if let Some(password) = self.sasl_password.as_deref() {
+                        let encoded = encode_sasl_plain(&current_nick, password);
+                        let mut guard = self.writer.lock().await;
+                        if let Some(ref mut w) = *guard {
+                            Self::send_raw(w, &format!("AUTHENTICATE {encoded}")).await?;
+                        }
+                    } else {
+                        // SASL was requested but no password is configured; abort SASL
+                        tracing::warn!(
+                            "SASL authentication requested but no SASL password is configured; aborting SASL"
+                        );
+                        sasl_pending = false;
+                        let mut guard = self.writer.lock().await;
+                        if let Some(ref mut w) = *guard {
+                            Self::send_raw(w, "CAP END").await?;
                         }
                     }
                 }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -5734,7 +5734,7 @@ pub async fn start_channels(config: Config) -> Result<()> {
                 (k, mt)
             })
             .collect();
-        keyed.sort_by(|a, b| b.1.cmp(&a.1));
+        keyed.sort_by_key(|b| std::cmp::Reverse(b.1));
         keyed.truncate(MAX_CONVERSATION_SENDERS);
         let session_keys: Vec<String> = keyed.into_iter().map(|(k, _)| k).collect();
 

--- a/src/channels/mqtt.rs
+++ b/src/channels/mqtt.rs
@@ -6,7 +6,7 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
-use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS, Transport};
+use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS, TlsConfiguration, Transport};
 use tracing::{info, warn};
 
 use crate::config::MqttConfig;
@@ -37,10 +37,10 @@ pub async fn run_mqtt_sop_listener(
         mqtt_options.set_credentials(user, pass);
     }
 
-    // Configure TLS transport when mqtts:// scheme is used
+    // Configure TLS transport when mqtts:// scheme is used.
     if config.use_tls {
-        mqtt_options.set_transport(Transport::tls_with_default_config());
-        info!("MQTT SOP listener: TLS transport enabled");
+        mqtt_options.set_transport(Transport::tls_with_config(TlsConfiguration::Native));
+        info!("MQTT SOP listener: native TLS transport enabled");
     }
 
     let (client, mut eventloop) = AsyncClient::new(mqtt_options, 64);

--- a/src/heartbeat/engine.rs
+++ b/src/heartbeat/engine.rs
@@ -249,7 +249,7 @@ impl HeartbeatEngine {
             .filter(HeartbeatTask::is_runnable)
             .collect();
         // Sort by priority descending (High > Medium > Low)
-        tasks.sort_by(|a, b| b.priority.cmp(&a.priority));
+        tasks.sort_by_key(|b| std::cmp::Reverse(b.priority));
         Ok(tasks)
     }
 

--- a/src/memory/cli.rs
+++ b/src/memory/cli.rs
@@ -157,7 +157,7 @@ async fn handle_stats(config: &Config) -> Result<()> {
 
         println!("\n  By category:");
         let mut sorted: Vec<_> = counts.into_iter().collect();
-        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
         for (cat, count) in sorted {
             println!("    {cat:<20} {count}");
         }

--- a/src/memory/knowledge_graph.rs
+++ b/src/memory/knowledge_graph.rs
@@ -527,7 +527,7 @@ impl KnowledgeGraph {
             }
         }
         let mut top_tags: Vec<(String, usize)> = tag_counts.into_iter().collect();
-        top_tags.sort_by(|a, b| b.1.cmp(&a.1));
+        top_tags.sort_by_key(|b| std::cmp::Reverse(b.1));
         top_tags.truncate(10);
 
         Ok(GraphStats {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -780,11 +780,7 @@ pub fn scrub_secret_patterns(input: &str) -> String {
 
     for prefix in PREFIXES {
         let mut search_from = 0;
-        loop {
-            let Some(rel) = scrubbed[search_from..].find(prefix) else {
-                break;
-            };
-
+        while let Some(rel) = scrubbed[search_from..].find(prefix) {
             let start = search_from + rel;
             let content_start = start + prefix.len();
             let end = token_end(&scrubbed, content_start);
@@ -1125,7 +1121,7 @@ fn create_provider_with_url_and_options(
     // Pre-flight: catch obvious API-key / provider mismatches early.
     if let Some(key_value) = key {
         let is_custom = name.starts_with("custom:") || name.starts_with("anthropic-custom:");
-        let has_custom_url = api_url.map(str::trim).filter(|u| !u.is_empty()).is_some();
+        let has_custom_url = api_url.as_ref().is_some_and(|u| !u.trim().is_empty());
         if !is_custom && !has_custom_url {
             if let Some(likely_provider) = check_api_key_prefix(name, key_value) {
                 let visible = &key_value[..key_value.len().min(8)];

--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -420,11 +420,7 @@ fn parse_sse_text(body: &str) -> anyhow::Result<Option<String>> {
         Ok(())
     };
 
-    loop {
-        let Some(idx) = buffer.find("\n\n") else {
-            break;
-        };
-
+    while let Some(idx) = buffer.find("\n\n") {
         let chunk = buffer[..idx].to_string();
         buffer = buffer[idx + 2..].to_string();
         process_chunk(&chunk)?;

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -1757,7 +1757,7 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
             for (name, result) in &results {
                 match result {
                     integrity::VerifyResult::Ok => {
-                        println!("  {} {}", console::style("✓").green().bold(), name,);
+                        println!("  {} {}", console::style("✓").green().bold(), name);
                     }
                     integrity::VerifyResult::NotLocked => {
                         println!(

--- a/src/skills/testing.rs
+++ b/src/skills/testing.rs
@@ -255,7 +255,7 @@ pub fn print_results(results: &[SkillTestResult]) {
                 r.tests_run,
             );
             for f in &r.failures {
-                println!("    command:  {}", console::style(&f.command).dim(),);
+                println!("    command:  {}", console::style(&f.command).dim());
                 println!(
                     "    expected: exit={}, pattern={}",
                     f.expected_exit, f.expected_pattern,

--- a/src/tools/cloud_patterns.rs
+++ b/src/tools/cloud_patterns.rs
@@ -164,7 +164,7 @@ impl CloudPatternsTool {
             })
             .collect();
 
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         // Built-in IaC examples are AWS Terraform only; include them only when
         // the cloud filter is unset or explicitly "aws".

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -565,7 +565,7 @@ impl DelegateTool {
             Err(e) => Ok(ToolResult {
                 success: false,
                 output: String::new(),
-                error: Some(format!("Agent '{agent_name}' failed: {e}",)),
+                error: Some(format!("Agent '{agent_name}' failed: {e}")),
             }),
         }
     }

--- a/src/tools/linkedin_client.rs
+++ b/src/tools/linkedin_client.rs
@@ -99,10 +99,8 @@ impl LinkedInClient {
                     "LINKEDIN_CLIENT_ID" => client_id = Some(value),
                     "LINKEDIN_CLIENT_SECRET" => client_secret = Some(value),
                     "LINKEDIN_ACCESS_TOKEN" => access_token = Some(value),
-                    "LINKEDIN_REFRESH_TOKEN" => {
-                        if !value.is_empty() {
-                            refresh_token = Some(value);
-                        }
+                    "LINKEDIN_REFRESH_TOKEN" if !value.is_empty() => {
+                        refresh_token = Some(value);
                     }
                     "LINKEDIN_PERSON_ID" => person_id = Some(value),
                     _ => {}

--- a/src/tools/mcp_transport.rs
+++ b/src/tools/mcp_transport.rs
@@ -761,7 +761,7 @@ impl McpTransportConn for SseTransport {
         let mut last_status = None;
 
         for (i, url) in std::iter::once(primary_url)
-            .chain(secondary_url.into_iter())
+            .chain(secondary_url)
             .enumerate()
         {
             let has_accept = self

--- a/src/tools/traits.rs
+++ b/src/tools/traits.rs
@@ -1,21 +1,6 @@
 use async_trait::async_trait;
+pub use hrafn_sdk::{ToolResult, ToolSpec};
 use serde::{Deserialize, Serialize};
-
-/// Result of a tool execution
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ToolResult {
-    pub success: bool,
-    pub output: String,
-    pub error: Option<String>,
-}
-
-/// Description of a tool for the LLM
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ToolSpec {
-    pub name: String,
-    pub description: String,
-    pub parameters: serde_json::Value,
-}
 
 /// Lightweight stub for tiered context injection — name + short description only.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/component/microkernel_profile.rs
+++ b/tests/component/microkernel_profile.rs
@@ -1,0 +1,42 @@
+#[test]
+fn cargo_declares_microkernel_seed_artifacts() {
+    let cargo_toml = std::fs::read_to_string("Cargo.toml").expect("read root Cargo.toml");
+
+    assert!(
+        cargo_toml.contains("\"crates/hrafn-sdk\"")
+            && cargo_toml.contains("\"crates/hrafn-kernel\""),
+        "workspace should include the SDK and kernel crates used as the microkernel boundary"
+    );
+    assert!(
+        std::path::Path::new("crates/hrafn-kernel/Cargo.toml").exists(),
+        "workspace should expose a tiny kernel seed package separate from the full CLI"
+    );
+    assert!(
+        cargo_toml.contains("kernel = [\"dep:hrafn-sdk\"]"),
+        "root features should include a minimal kernel feature that does not imply desktop integrations"
+    );
+    assert!(
+        cargo_toml.contains("full = ["),
+        "root features should name the full distribution profile explicitly"
+    );
+}
+
+#[test]
+fn sdk_crate_stays_dependency_light() {
+    let sdk_toml =
+        std::fs::read_to_string("crates/hrafn-sdk/Cargo.toml").expect("read hrafn-sdk Cargo.toml");
+
+    for forbidden in [
+        "reqwest",
+        "axum",
+        "ratatui",
+        "rusqlite",
+        "matrix-sdk",
+        "wa-rs",
+    ] {
+        assert!(
+            !sdk_toml.contains(forbidden),
+            "hrafn-sdk must not depend on heavyweight integration crate {forbidden}"
+        );
+    }
+}

--- a/tests/component/microkernel_profile.rs
+++ b/tests/component/microkernel_profile.rs
@@ -1,22 +1,43 @@
 #[test]
 fn cargo_declares_microkernel_seed_artifacts() {
     let cargo_toml = std::fs::read_to_string("Cargo.toml").expect("read root Cargo.toml");
+    let parsed: toml::Value = toml::from_str(&cargo_toml).expect("parse root Cargo.toml");
 
+    let workspace_members = parsed
+        .get("workspace")
+        .and_then(|workspace| workspace.get("members"))
+        .and_then(toml::Value::as_array)
+        .expect("workspace.members should be an array");
     assert!(
-        cargo_toml.contains("\"crates/hrafn-sdk\"")
-            && cargo_toml.contains("\"crates/hrafn-kernel\""),
+        workspace_members
+            .iter()
+            .any(|member| member.as_str() == Some("crates/hrafn-sdk"))
+            && workspace_members
+                .iter()
+                .any(|member| member.as_str() == Some("crates/hrafn-kernel")),
         "workspace should include the SDK and kernel crates used as the microkernel boundary"
     );
     assert!(
         std::path::Path::new("crates/hrafn-kernel/Cargo.toml").exists(),
         "workspace should expose a tiny kernel seed package separate from the full CLI"
     );
+
+    let features = parsed
+        .get("features")
+        .and_then(toml::Value::as_table)
+        .expect("root Cargo.toml should have a [features] table");
+    let kernel = features
+        .get("kernel")
+        .and_then(toml::Value::as_array)
+        .expect("root features should include a minimal kernel feature");
     assert!(
-        cargo_toml.contains("kernel = [\"dep:hrafn-sdk\"]"),
-        "root features should include a minimal kernel feature that does not imply desktop integrations"
+        kernel
+            .iter()
+            .any(|feature| feature.as_str() == Some("dep:hrafn-sdk")),
+        "root kernel feature should include dep:hrafn-sdk without implying desktop integrations"
     );
     assert!(
-        cargo_toml.contains("full = ["),
+        features.contains_key("full"),
         "root features should name the full distribution profile explicitly"
     );
 }
@@ -25,7 +46,9 @@ fn cargo_declares_microkernel_seed_artifacts() {
 fn sdk_crate_stays_dependency_light() {
     let sdk_toml =
         std::fs::read_to_string("crates/hrafn-sdk/Cargo.toml").expect("read hrafn-sdk Cargo.toml");
+    let parsed: toml::Value = toml::from_str(&sdk_toml).expect("parse hrafn-sdk Cargo.toml");
 
+    let dependency_keys = dependency_table_keys(&parsed);
     for forbidden in [
         "reqwest",
         "axum",
@@ -35,8 +58,36 @@ fn sdk_crate_stays_dependency_light() {
         "wa-rs",
     ] {
         assert!(
-            !sdk_toml.contains(forbidden),
+            !dependency_keys
+                .iter()
+                .any(|dependency| dependency == forbidden),
             "hrafn-sdk must not depend on heavyweight integration crate {forbidden}"
         );
+    }
+}
+
+fn dependency_table_keys(manifest: &toml::Value) -> Vec<String> {
+    let mut keys = Vec::new();
+    collect_dependency_table_keys(manifest, &mut keys);
+    keys
+}
+
+fn collect_dependency_table_keys(value: &toml::Value, keys: &mut Vec<String>) {
+    let Some(table) = value.as_table() else {
+        return;
+    };
+
+    for (name, child) in table {
+        if matches!(
+            name.as_str(),
+            "dependencies" | "dev-dependencies" | "build-dependencies"
+        ) || name.ends_with("-dependencies")
+        {
+            if let Some(dependencies) = child.as_table() {
+                keys.extend(dependencies.keys().cloned());
+            }
+        }
+
+        collect_dependency_table_keys(child, keys);
     }
 }

--- a/tests/component/mod.rs
+++ b/tests/component/mod.rs
@@ -3,6 +3,7 @@ mod config_schema;
 mod dockerignore_test;
 mod gateway;
 mod gemini_capabilities;
+mod microkernel_profile;
 mod otel_dependency_feature_regression;
 mod provider_resolution;
 mod provider_schema;


### PR DESCRIPTION
## What

Seeds the Hrafn microkernel migration without changing the historical default distribution behavior.

- Adds `crates/hrafn-sdk` as a dependency-light SDK/protocol boundary for kernel and plugin types.
- Adds `crates/hrafn-kernel` as a tiny standalone kernel seed crate/binary.
- Adds permission-aware `KernelRegistry` primitives with tests.
- Moves stable tool wire types (`ToolResult`, `ToolSpec`) into `hrafn-sdk` and re-exports them from the existing tool trait module for compatibility.
- Makes the old monolithic default profile explicit as `full` (`default = ["full"]`).
- Adds `docs/architecture/microkernel.md` and `dev/measure-microkernel.sh` for migration guidance and dependency-size measurement.
- Adds component tests to guard the SDK/kernel boundary against heavyweight integration dependencies.

This is the first safe slice of the migration: it establishes the new crate/protocol boundary and preserves the current full build behavior. Follow-up PRs can extract providers, shell tools, gateway, and TUI into SDK-backed plugin crates.

## How to test

```bash
cargo build -p hrafn-sdk --no-default-features
cargo check -p hrafn-sdk --all-features
cargo check -p hrafn-kernel
cargo test -p hrafn-kernel
cargo clippy -p hrafn-kernel -- -D warnings
cargo clippy -p hrafn-sdk --all-features -- -D warnings
cargo check --bin hrafn --features full
cargo test --test component microkernel_profile
./dev/measure-microkernel.sh kernel
cargo fmt --all -- --check
git diff --check
```

## Breaking changes

- [ ] This PR includes breaking changes

**Migration:** None. `default = ["full"]` preserves the historical default feature set. Existing `hrafn::tools::{ToolResult, ToolSpec}` imports continue to work through re-exports.

## Security

- [ ] New network calls or endpoints
- [ ] Secrets/tokens handling changed
- [ ] File system access scope changed
- [ ] SSRF / input validation implications

**Risk and mitigation:** Low-to-medium architecture change. The new kernel registry only adds local permission checking primitives and does not grant new runtime access. Boundary tests ensure `hrafn-sdk` stays free of heavyweight/network integration crates.

## Checklist

- [x] `cargo fmt && cargo clippy -D warnings` passes for changed crates
- [x] Tests pass, new code has tests
- [x] I can explain every line in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin SDK and kernel crate enabling an extensible plugin architecture
  * Kernel registry with permission-checked plugin registration
  * New `kernel` and `full` build profiles and optional SDK dependency

* **Documentation**
  * Microkernel architecture guide and measurement/benchmarking script

* **Improvements**
  * MQTT now uses native TLS on supported builds
  * CI job timeout increased to reduce spurious cancellations

* **Tests**
  * Component tests enforcing microkernel/profile constraints and registry behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->